### PR TITLE
Resubmit #49

### DIFF
--- a/yang/IETF-02/ietf-l3vpn-ntw.yang
+++ b/yang/IETF-02/ietf-l3vpn-ntw.yang
@@ -1,2684 +1,2142 @@
 module ietf-l3vpn-ntw {
- yang-version 1.1;
- namespace "urn:ietf:params:xml:ns:yang:ietf-l3vpn-ntw";
- prefix l3vpn-ntw;
-  
- import ietf-inet-types {
-  prefix inet;
-  reference "Section 4 of RFC 6991";
- }
- import ietf-yang-types {
-  prefix yang;
-  reference "Section 3 of RFC 6991";
- }
- import ietf-netconf-acm {
-  prefix nacm;
-  reference
-    "RFC 8341: Network Configuration Access Control Model";
- }
- import ietf-routing-types {
+  yang-version 1.1;
+  namespace "urn:ietf:params:xml:ns:yang:ietf-l3vpn-ntw";
+  prefix l3vpn-ntw;
+
+  import ietf-inet-types {
+    prefix inet;
+    reference
+      "Section 4 of RFC 6991";
+  }
+  import ietf-yang-types {
+    prefix yang;
+    reference
+      "Section 3 of RFC 6991";
+  }
+  import ietf-netconf-acm {
+    prefix nacm;
+    reference
+      "RFC 8341: Network Configuration Access Control Model";
+  }
+  import ietf-routing-types {
     prefix rt-types;
     reference
       "RFC 8294: Common YANG Data Types for the Routing Area";
- }
- organization
-   "IETF OPSA (Operations and Management Area) Working Group ";
- contact
-   "WG Web:   <http://tools.ietf.org/wg/opsawg/>
-       WG List:  <mailto:opsawg@ietf.org>
-       Editor:    Oscar Gonzalez de Dios
-                 <mailto:oscar.gonzalezdedios@telefonica.com>
-       Editor:    Alejandro Aguado
-                 <mailto:alejandro.aguado_martin@nokia.com>
-       Editor:    Victor Lopez
-                 <mailto:victor.lopezalvarez@telefonica.com>
-       Editor:    Daniel Voyer
-                 <mailto:daniel.voyer@bell.ca>
-   ";
+  }
+  import ietf-l3vpn-svc {
+    prefix l3vpn-svc;
+    reference
+      "RFC 8299: YANG Data Model for L3VPN Service Delivery";
+  }
 
-   description
-     "This YANG module defines a generic network-oriented model
-      for the configuration of Layer 3 VPNs.
-      Copyright (c) 2020 IETF Trust and the persons identified as
-      authors of the code.  All rights reserved.
+  organization
+    "IETF OPSA (Operations and Management Area) Working Group ";
+  contact
+    "WG Web:   <http://tools.ietf.org/wg/opsawg/>
+        WG List:  <mailto:opsawg@ietf.org>
+        Editor:    Oscar Gonzalez de Dios
+                  <mailto:oscar.gonzalezdedios@telefonica.com>
+        Author:    Alejandro Aguado
+                  <mailto:alejandro.aguado_martin@nokia.com>
+        Author:    Victor Lopez
+                  <mailto:victor.lopezalvarez@telefonica.com>
+        Author:    Daniel Voyer
+                  <mailto:daniel.voyer@bell.ca>
+        Author:   Mohamed Boucadair
+                  <mailto:mohamed.boucadair@orange.com>
+     
+    ";
+  description
+    "This YANG module defines a generic network-oriented model
+     for the configuration of Layer 3 VPNs.
+     Copyright (c) 2020 IETF Trust and the persons identified as
+     authors of the code.  All rights reserved.
 
-      Redistribution and use in source and binary forms, with or
-      without modification, is permitted pursuant to, and subject to
-      the license terms contained in, the Simplified BSD License set
-      forth in Section 4.c of the IETF Trust's Legal Provisions
-      Relating to IETF Documents
-      (https://trustee.ietf.org/license-info).
+     Redistribution and use in source and binary forms, with or
+     without modification, is permitted pursuant to, and subject to
+     the license terms contained in, the Simplified BSD License set
+     forth in Section 4.c of the IETF Trust's Legal Provisions
+     Relating to IETF Documents
+     (https://trustee.ietf.org/license-info).
 
-      This version of this YANG module is part of RFC XXXX
-      (https://www.rfc-editor.org/info/rfcXXXX); see the RFC itself
-      for full legal notices.
+     This version of this YANG module is part of RFC XXXX
+     (https://www.rfc-editor.org/info/rfcXXXX); see the RFC itself
+     for full legal notices.
 
-      The key words 'MUST', 'MUST NOT', 'REQUIRED', 'SHALL', 'SHALL
-      NOT', 'SHOULD', 'SHOULD NOT', 'RECOMMENDED', 'NOT RECOMMENDED',
-      'MAY', and 'OPTIONAL' in this document are to be interpreted as
-      described in BCP 14 (RFC 2119) (RFC 8174) when, and only when,
-      they appear in all capitals, as shown here.";
+     The key words 'MUST', 'MUST NOT', 'REQUIRED', 'SHALL', 'SHALL
+     NOT', 'SHOULD', 'SHOULD NOT', 'RECOMMENDED', 'NOT RECOMMENDED',
+     'MAY', and 'OPTIONAL' in this document are to be interpreted as
+     described in BCP 14 (RFC 2119) (RFC 8174) when, and only when,
+     they appear in all capitals, as shown here.";
 
-   revision 2020-02-04 {
+  revision 2020-02-04 {
     description
       "Initial revision.";
     reference
       "RFC XXXX: A Layer 3 VPN Network YANG Model";
-    }
-
- /* Features */
- 
- feature cloud-access {
-  description
-    "This feature indicates that the VPN
-     can connect to a Cloud Service Provider (CSP).";
   }
- feature multicast {
-  description
-    "This feature indicates that multicast capabilities
-     are supported by the VPN.";
- }
- feature ipv4 {
-  description
-    "This feature indicates IPv4 support in a VPN.";
- }
- feature ipv6 {
-  description
-    "This feature indicates IPv6 support in a VPN.";
- }
- feature lan-tag {
-  description
-    "This feature indicates LAN Tag support in a VPN
-     Policy filter.";
- }
- feature carrierscarrier {
-  description
-    "This feature indicates support of Carriers' Carriers.";
-  reference
-    "RFC 4364: BGP/MPLS IP Virtual Private Networks (VPNs)";
- }
- feature extranet-vpn {
-  description
-    "If the various sites in a VPN are owned
-     by different enterprises, the VPN may be thought of 
-     as an 'extranet'.
-     
-     This features indicates the support of extranet VPNs.";
- }
- feature encryption {
-  description
-    "This feature indicates the support of encryption.";
- }
- feature qos {
-  description
-    "This features indicates the support of classes of services.";
- }
- feature qos-custom {
-  description
-    "This features indicates the support of a custom QoS profile.";
- }
- feature rtg-bgp {
-  description
-    "This features indicates the support of the BGP
-     routing protocol.";
- }
- feature rtg-rip {
-  description
-    "This features indicates the support of the RIP
-     routing protocol.";
- }
- feature rtg-ospf {
-  description
-    "This features indicates the support of the OSPF
-     routing protocol.";
- }
- feature rtg-ospf-sham-link {
-  description
-   "This feature indicates the support of OSPF sham links.";
- }
- feature rtg-vrrp {
-  description
-    "This feature indicates the support of Virtual Router 
-     Redundancy Protocol (VRRP)";
- }
- feature fast-reroute {
-  description
-    "This feature indicates the support of Fast Reroute.";
- }
- feature bfd {
-  description
-    "This feature indciates the support of BFD.";
- }
- feature bearer-reference {
-  description
-    "This feature indicates the support of the 'bearer-reference'
-     access constraint.";
- }
- feature target-sites {
-  description
-    "This features indicates the support of 
-     the 'target-sites' match flow parameter.";
- }
-feature input-bw {
-  description
-    "This feature indicates the support of 
-     the 'input-bw' limit.";
- }
-feature dot1q  {
-  description
-    "This feature indicates the support of
-     the 'dot1q' encapsulation.";
- }
-feature qinq  {
-  description
-    "This feature indicates the support of
-     the 'qinq' encapsulation.";
- }
-feature qinany  {
-  description
-    "This feature indicates the support of
-     the 'qinany' encapsulation.";
- }
- feature vxlan  {
-  description
-    "This feature indicates the support of
-     the 'vxlan' encapsulation.";
- }
 
- /* Typedefs */
- 
- typedef svc-id {
-  type string;
-  description
-    "Defines a type of service component identifier.";
- }
- typedef template-id {
-  type string;
-  description
-    "Defines a type of service template identifier.";
- }
- typedef address-family {
-  type enumeration {
-   enum ipv4 {
+  /* Features */
+
+  feature rtg-ospf-sham-link {
     description
-    "IPv4 address family.";
-   }
-   enum ipv6 {
-    description
-    "IPv6 address family.";
-   }
-   enum ipv4/ipv6 {
-    description
-    "IPv4/IPv6 address family.";
-   }
+      "This feature indicates the support of OSPF sham links.";
   }
-  description
-  "Defines a type for the address family.";
- }
+
+  feature input-bw {
+    description
+      "This feature indicates the support of
+       the 'input-bw' limit.";
+  }
+
+  feature dot1q {
+    description
+      "This feature indicates the support of
+       the 'dot1q' encapsulation.";
+  }
+
+  feature qinq {
+    description
+      "This feature indicates the support of
+       the 'qinq' encapsulation.";
+  }
+
+  feature qinany {
+    description
+      "This feature indicates the support of
+       the 'qinany' encapsulation.";
+  }
+
+  feature vxlan {
+    description
+      "This feature indicates the support of
+       the 'vxlan' encapsulation.";
+  }
+
+  /* Typedefs */
 
   typedef ie-type {
-   type enumeration {
-     enum import {
-       value 0;
-       description "Import a routing profile.";
-     }
-     enum export {
-      value 1;
-      description "Export a routing profile";
-     }
-     enum both {
-      value 2;
-      description "Import/Export a routing profile";
-     }
-   }
-  description
-    "Defines Import-Export routing profiles.
-     Those are able to be reused between vpn-nodes";
+    type enumeration {
+      enum import {
+        value 0;
+        description
+          "Import a routing profile.";
+      }
+      enum export {
+        value 1;
+        description
+          "Export a routing profile";
+      }
+      enum both {
+        value 2;
+        description
+          "Import/Export a routing profile";
+      }
+    }
+    description
+      "Defines Import-Export routing profiles.
+       Those are able to be reused between vpn-nodes.";
   }
 
   typedef operational-type {
-   type enumeration {
-     enum up {
-       value 0;
-       description "Operational status UP.";
-     }
-     enum down {
-      value 1;
-      description "Operational status DOWN";
-     }
-     enum unknown {
-      value 2;
-      description "Operational status UNKNOWN";
-     }
-   }
-   description
-    "This is a read-only attribute used to determine the
-     status of a particular element.";
+    type enumeration {
+      enum up {
+        value 0;
+        description
+          "Operational status UP.";
+      }
+      enum down {
+        value 1;
+        description
+          "Operational status DOWN";
+      }
+      enum unknown {
+        value 2;
+        description
+          "Operational status UNKNOWN";
+      }
+    }
+    description
+      "This is a read-only attribute used to determine the
+       status of a particular element.";
   }
 
- /* Identities */
- identity site-network-access-type {
-  description
-  "Base identity for site-network-access type.";
- }
- identity point-to-point {
-  base site-network-access-type;
-  description
-  "Identity for point-to-point connections.";
- }
- /* Extension */
- identity pseudowire {
-  base site-network-access-type;
-  description
-  "Identity for pseudowire connections.";
- }
-  identity vpls {
-  base site-network-access-type;
-  description
-  "Identity for vpls connection.";
- }
+  /* Identities */
+
+  identity pseudowire {
+    base l3vpn-svc:site-network-access-type;
+    description
+      "Identity for pseudowire connections.";
+  }
+
   identity loopback {
-  base site-network-access-type;
-  description
-    "Identity for loopback connections.";
- }
- /* End of Extension */
- identity multipoint {
-  base site-network-access-type;
-  description
-  "Identity for multipoint connections.
-  Example: Ethernet broadcast segment.";
- }
- identity customer-application {
-  description
-  "Base identity for customer applications.";
- }
- identity web {
-  base customer-application;
-  description
-  "Identity for Web applications (e.g., HTTP, HTTPS).";
- }
- identity mail {
-  base customer-application;
-  description
-  "Identity for mail applications.";
- }
- identity file-transfer {
-  base customer-application;
-  description
-  "Identity for file transfer applications (e.g., FTP, SFTP).";
- }
- identity database {
-  base customer-application;
-  description
-  "Identity for database applications.";
- }
- identity social {
-  base customer-application;
-  description
-  "Identity for social-network applications.";
- }
- identity games {
-  base customer-application;
-  description
-  "Identity for gaming applications.";
- }
- identity p2p {
-  base customer-application;
-  description
-  "Identity for peer-to-peer applications.";
- }
- identity network-management {
-  base customer-application;
-  description
-  "Identity for management applications
-  (e.g., Telnet, syslog, SNMP).";
- }
- identity voice {
-  base customer-application;
-  description
-  "Identity for voice applications.";
- }
- identity video {
-  base customer-application;
-  description
-  "Identity for video conference applications.";
- }
- identity embb {
-  base customer-application;
-  description
-  "Identity for an enhanced Mobile Broadband (eMBB)
-  application.  Note that an eMBB application demands
-  network performance with a wide variety of
-  characteristics, such as data rate, latency,
-  loss rate, reliability, and many other parameters.";
-}
-identity urllc {
-  base customer-application;
-  description
-  "Identity for an Ultra-Reliable and Low Latency
-  Communications (URLLC) application.  Note that a
-  URLLC application demands network performance
-  with a wide variety of characteristics, such as latency,
-  reliability, and many other parameters.";
- }
- identity mmtc {
-   base customer-application;
-   description
-   "Identity for a massive Machine Type
-   Communications (mMTC) application.  Note that an
-   mMTC application demands network performance
-   with a wide variety of characteristics, such as data
-   rate, latency, loss rate, reliability, and many
-   other parameters.";
- }
- identity address-allocation-type {
-  description
-  "Base identity for address-allocation-type for PE-CE link.";
- }
- identity provider-dhcp {
-  base address-allocation-type;
-  description
-  "Provider network provides DHCP service to customer.";
- }
- identity provider-dhcp-relay {
-  base address-allocation-type;
-  description
-  "Provider network provides DHCP relay service to customer.";
- }
- identity provider-dhcp-slaac {
-  base address-allocation-type;
-  description
-  "Provider network provides DHCP service to customer,
-  as well as SLAAC.";
- }
- identity static-address {
-  base address-allocation-type;
-  description
-  "Provider-to-customer addressing is static.";
- }
- identity slaac {
-  base address-allocation-type;
-  description
-  "Use IPv6 SLAAC.";
- }
- identity site-role {
-  description
-  "Base identity for site type.";
- }
- identity any-to-any-role {
-  base site-role;
-  description
-  "Site in an any-to-any IP VPN.";
- }
- identity spoke-role {
-  base site-role;
-  description
-  "Spoke site in a Hub-and-Spoke IP VPN.";
- }
- identity hub-role {
-  base site-role;
-  description
-  "Hub site in a Hub-and-Spoke IP VPN.";
- }
- identity vpn-topology {
-  description
-  "Base identity for VPN topology.";
- }
- identity any-to-any {
-  base vpn-topology;
-  description
-  "Identity for any-to-any VPN topology.";
- }
- identity hub-spoke {
-  base vpn-topology;
-  description
-  "Identity for Hub-and-Spoke VPN topology.";
- }
- identity hub-spoke-disjoint {
-  base vpn-topology;
-  description
-  "Identity for Hub-and-Spoke VPN topology
-  where Hubs cannot communicate with each other.";
- }
-  identity custom {
-  base vpn-topology;
-  description
-   "Identity for CUSTOM VPN topology
-    where Hubs can act as Spoke for certain part of 
-    the network or Spokes as Hubs.";
- }
- identity multicast-tree-type {
-  description
-  "Base identity for multicast tree type.";
- }
- identity ssm-tree-type {
-  base multicast-tree-type;
-  description
-  "Identity for Source-Specific Multicast (SSM) tree type.";
- }
- identity asm-tree-type {
-  base multicast-tree-type;
-  description
-  "Identity for Any-Source Multicast (ASM) tree type.";
- }
- identity bidir-tree-type {
-  base multicast-tree-type;
-  description
-  "Identity for bidirectional tree type.";
- }
- identity multicast-rp-discovery-type {
-  description
-  "Base identity for Rendezvous Point (RP) discovery type.";
- }
- identity auto-rp {
-  base multicast-rp-discovery-type;
-  description
-  "Base identity for Auto-RP discovery type.";
- }
- identity static-rp {
-  base multicast-rp-discovery-type;
-  description
-  "Base identity for static type.";
- }
- identity bsr-rp {
-  base multicast-rp-discovery-type;
-  description
-  "Base identity for Bootstrap Router (BSR) discovery type.";
- }
- identity routing-protocol-type {
-  description
-  "Base identity for routing protocol type.";
- }
- identity ospf {
-  base routing-protocol-type;
-  description
-  "Identity for OSPF protocol type.";
- }
- identity bgp {
-  base routing-protocol-type;
-  description
-  "Identity for BGP protocol type.";
- }
- identity static {
-  base routing-protocol-type;
-  description
-  "Identity for static routing protocol type.";
- }
- identity rip {
-  base routing-protocol-type;
-  description
-  "Identity for RIP protocol type.";
- }
- identity vrrp {
-  base routing-protocol-type;
-  description
-  "Identity for VRRP protocol type.
-  This is to be used when LANs are directly connected
-  to PE routers.";
- }
- identity direct {
-  base routing-protocol-type;
-  description
-  "Identity for direct protocol type.";
- }
- identity protocol-type {
-  description
-  "Base identity for protocol field type.";
- }
- identity tcp {
-  base protocol-type;
-  description
-  "TCP protocol type.";
- }
- identity udp {
-  base protocol-type;
-  description
-  "UDP protocol type.";
- }
- identity icmp {
-  base protocol-type;
-  description
-  "ICMP protocol type.";
- }
- identity icmp6 {
-  base protocol-type;
-  description
-  "ICMPv6 protocol type.";
- }
- identity gre {
-  base protocol-type;
-  description
-  "GRE protocol type.";
- }
- identity ipip {
-  base protocol-type;
-  description
-  "IP-in-IP protocol type.";
- }
- identity hop-by-hop {
-  base protocol-type;
-  description
-  "Hop-by-Hop IPv6 header type.";
- }
- identity routing {
-  base protocol-type;
-  description
-  "Routing IPv6 header type.";
- }
- identity esp {
-  base protocol-type;
-  description
-  "ESP (Encapsulating Security Payload) header type.";
- }
- identity ah {
-  base protocol-type;
-  description
-  "AH (Authentication Header) header type.";
- }
- identity vpn-policy-filter-type {
-  description
-  "Base identity for VPN policy filter type.";
- }
- identity ipv4 {
-   base vpn-policy-filter-type;
-   description
-   "Identity for IPv4 prefix filter type.";
- }
- identity ipv6 {
-   base vpn-policy-filter-type;
-   description
-   "Identity for IPv6 prefix filter type.";
-}
- identity lan {
-   base vpn-policy-filter-type;
-   description
-   "Identity for LAN Tag filter type.";
-}
-identity qos-profile-direction {
-  description
-  "Base identity for QoS profile direction.";
- }
-identity site-to-wan {
-   base qos-profile-direction;
-   description
-   "Identity for Site-to-WAN direction.";
- }
- identity wan-to-site {
-   base qos-profile-direction;
-   description
-   "Identity for WAN-to-Site direction.";
- }
- identity both {
-   base qos-profile-direction;
-   description
-   "Identity for both WAN-to-Site direction
-   and Site-to-WAN direction.";
- }
+    base l3vpn-svc:site-network-access-type;
+    description
+      "Identity for loopback connections.";
+  }
 
- /* Extended Identities */
-
- identity encapsulation-type {
+  identity encapsulation-type {
     description
       "Identity for the encapsulation type.";
   }
- identity untagged-int {
+
+  identity untagged-int {
     base encapsulation-type;
     description
       "Identity for Ethernet type.";
   }
+
   identity tagged-int {
     base encapsulation-type;
     description
       "Identity for the VLAN type.";
   }
+
   identity eth-inf-type {
     description
       "Identity of the Ethernet interface type.";
   }
+
   identity tagged {
     base eth-inf-type;
     description
       "Identity of the tagged interface type.";
   }
+
   identity untagged {
     base eth-inf-type;
     description
       "Identity of the untagged interface type.";
   }
+
   identity lag {
     base eth-inf-type;
     description
       "Identity of the LAG interface type.";
   }
+
   identity bearer-inf-type {
     description
       "Identity for the bearer interface type.";
   }
+
   identity port-id {
     base bearer-inf-type;
     description
       "Identity for the priority-tagged interface.";
   }
+
   identity lag-id {
     base bearer-inf-type;
     description
       "Identity for the priority-tagged interface.";
   }
+
   identity tagged-inf-type {
     description
       "Identity for the tagged interface type.";
   }
+
   identity priority-tagged {
     base tagged-inf-type;
     description
       "Identity for the priority-tagged interface.";
   }
+
   identity qinq {
     base tagged-inf-type;
     description
       "Identity for the QinQ tagged interface.";
   }
+
   identity dot1q {
     base tagged-inf-type;
     description
       "Identity for the dot1Q VLAN tagged interface.";
   }
+
   identity qinany {
     base tagged-inf-type;
     description
       "Identity for the QinAny tagged interface.";
   }
+
   identity vxlan {
     base tagged-inf-type;
     description
       "Identity for the VXLAN tagged interface.";
   }
+
   identity tag-type {
     description
       "Base identity from which all tag types are derived.";
   }
+
   identity c-vlan {
     base tag-type;
     description
       "A CVLAN tag, normally using the 0x8100 Ethertype.";
   }
+
   identity s-vlan {
     base tag-type;
     description
       "An SVLAN tag.";
   }
+
   identity c-s-vlan {
     base tag-type;
     description
       "Using both a CVLAN tag and an SVLAN tag.";
   }
+
   identity vxlan-peer-mode {
     description
       "Base identity for the VXLAN peer mode.";
   }
+
   identity static-mode {
     base vxlan-peer-mode;
     description
       "Identity for VXLAN access in the static mode.";
   }
+
   identity bgp-mode {
     base vxlan-peer-mode;
     description
       "Identity for VXLAN access by BGP EVPN learning.";
   }
+
   identity bw-direction {
     description
       "Identity for the bandwidth direction.";
   }
+
   identity input-bw {
     base bw-direction;
     description
       "Identity for the input bandwidth.";
   }
+
   identity output-bw {
     base bw-direction;
     description
       "Identity for the output bandwidth.";
   }
+
   identity bw-type {
     description
       "Identity of the bandwidth type.";
   }
+
   identity bw-per-cos {
     base bw-type;
     description
       "Bandwidth is per CoS.";
   }
+
   identity bw-per-port {
     base bw-type;
     description
       "Bandwidth is per site network access.";
   }
+
   identity bw-per-site {
     base bw-type;
     description
       "Bandwidth is per site.  It is applicable to
        all the site network accesses within the site.";
   }
+
   identity bw-per-svc {
     base bw-type;
     description
       "Bandwidth is per VPN service.";
   }
 
- /* Groupings */
- grouping multicast-rp-group-cfg {
-  choice group-format {
-   mandatory true;
-   case singleaddress {
-    leaf group-address {
-     type inet:ip-address;
-     description
-     "A single multicast group address.";
-    }
-   }
-   case startend {
-    leaf group-start {
-     type inet:ip-address;
-     description
-     "The first multicast group address in
-     the multicast group address range.";
-    }
-    leaf group-end {
-     type inet:ip-address;
-     description
-     "The last multicast group address in
-     the multicast group address range.";
-    }
-   }
-   description
-   "Choice for multicast group format.";
-  }
-  description
-  "This grouping defines multicast group or
-  multicast groups for RP-to-group mapping.";
- }
- grouping vpn-service-multicast {
-  container multicast {
-   if-feature multicast;
-   leaf enabled {
-    type boolean;
-    default false;
-    description
-    "Enables multicast.";
-   }
-   container customer-tree-flavors {
-    leaf-list tree-flavor {
-     type identityref {
-      base multicast-tree-type;
-     }
-     description
-      "Type of tree to be used.";
-    }
-    description
-    "Type of trees used by customer.";
-   }
-   container rp {
-    container rp-group-mappings {
-     list rp-group-mapping {
-      key id;
-      leaf id {
-       type uint16;
-       description
-       "Unique identifier for the mapping.";
-      }
-      container provider-managed {
-       leaf enabled {
-        type boolean;
-        default false;
-        description
-        "Set to true if the Rendezvous Point (RP)
-        must be a provider-managed node.  Set to false
-        if it is a customer-managed node.";
-       }
-       leaf rp-redundancy {
-        type boolean;
-        default false;
-        description
-        "If true, a redundancy mechanism for the RP
-        is required.";
-       }
-       leaf optimal-traffic-delivery {
-        type boolean;
-        default false;
-        description
-        "If true, the SP must ensure that
-        traffic uses an optimal path.  An SP may use
-        Anycast RP or RP-tree-to-SPT switchover
-        architectures.";
-       }
-       description
-       "Parameters for a provider-managed RP.";
-      }
-      leaf rp-address {
-       when "../provider-managed/enabled = 'false'" {
-        description
-        "Relevant when the RP is not provider-managed.";
-       }
-       type inet:ip-address;
-         mandatory true;
-       description
-       "Defines the address of the RP.
-       Used if the RP is customer-managed.";
-      }
-      container groups {
-       list group {
-        key id;
-        leaf id {
-         type uint16;
-         description
-         "Identifier for the group.";
-        }
-        uses multicast-rp-group-cfg;
-        description
-        "List of multicast groups.";
-       }
-       description
-       "Multicast groups associated with the RP.";
-      }
-      description
-      "List of RP-to-group mappings.";
-     }
-     description
-     "RP-to-group mappings parameters.";
-    }
-    container rp-discovery {
-     leaf rp-discovery-type {
-      type identityref {
-       base multicast-rp-discovery-type;
-       }
-      default static-rp;
-      description
-      "Type of RP discovery used.";
-     }
-     container bsr-candidates {
-       when "derived-from-or-self(../rp-discovery-type, "+
-           "'l3vpn-ntw:bsr-rp')" {
-       description
-       "Only applicable if discovery type
-       is BSR-RP.";
-      }
-      leaf-list bsr-candidate-address {
-       type inet:ip-address;
-        description
-        "Address of BSR candidate.";
-      }
-      description
-      "Container for List of Customer
-      BSR candidate's addresses.";
-     }
-     description
-     "RP discovery parameters.";
-    }
-    description
-    "RP parameters.";
-   }
-   description
-   "Multicast global parameters for the VPN service.";
-  }
-  description
-  "Grouping for multicast VPN definition.";
- }
- grouping vpn-service-mpls {
-  leaf carrierscarrier {
-   if-feature carrierscarrier;
-    type boolean;
-    default false;
-    description
-    "The VPN is using CsC, and so MPLS is required.";
-  }
-  description
-  "Grouping for MPLS Carriers'Carrier definition.";
- }
- grouping operational-requirements {
-   leaf requested-site-start {
-    type yang:date-and-time;
-     description
-     "Optional leaf indicating requested date and
-     time when the service at a particular site is
-     expected to start.";
-  }
-  leaf requested-site-stop {
-    type yang:date-and-time;
-     description
-     "Optional leaf indicating requested date and
-     time when the service at a particular site is
-     expected to stop.";
-  }
-  description
-  "This grouping defines some operational
-  parameters.";
- }
- grouping operational-requirements-ops {
-   leaf actual-site-start {
-    type yang:date-and-time;
-    config false;
-     description
-     "Optional leaf indicating actual date and
-     time when the service at a particular site
-     actually started.";
-  }
-  leaf actual-site-stop {
-   type yang:date-and-time;
-   config false;
-     description
-     "Optional leaf indicating actual date and
-     time when the service at a particular site
-     actually stopped.";
-  }
-  description
-  "This grouping defines some operational
-  parameters.";
- }
- grouping flow-definition {
-  container match-flow {
-   leaf dscp {
-    type inet:dscp;
-     description
-     "DSCP value.";
-   }
-   leaf dot1p {
-    type uint8 {
-     range "0..7";
-    }
-    description
-    "802.1p matching.";
-   }
-   leaf ipv4-src-prefix {
-    type inet:ipv4-prefix;
-     description
-     "Match on IPv4 src address.";
-   }
-   leaf ipv6-src-prefix {
-    type inet:ipv6-prefix;
-     description
-     "Match on IPv6 source address.";
-   }
-   leaf ipv4-dst-prefix {
-    type inet:ipv4-prefix;
-     description
-     "Match on IPv4 destination address.";
-   }
-   leaf ipv6-dst-prefix {
-    type inet:ipv6-prefix;
-    description
-    "Match on IPv6 destination address.";
-   }
-   leaf l4-src-port {
-    type inet:port-number;
-        must "current() < ../l4-src-port-range/lower-port or "+
-        "current() > ../l4-src-port-range/upper-port" {
-     description
-     "If l4-src-port and l4-src-port-range/lower-port and
-     upper-port are set at the same time, l4-src-port
-     should not overlap with l4-src-port-range.";
-     }
-     description
-     "Match on Layer 4 src port.";
-   }
-   leaf-list target-sites {
-     if-feature target-sites;
-     type svc-id;
-     description
-     "Identify a site as traffic destination.";
-   }
-   container l4-src-port-range {
-     leaf lower-port {
-     type inet:port-number;
-     description
-     "Lower boundary for port.";
-    }
-    leaf upper-port {
-     type inet:port-number;
-     must ". >= ../lower-port" {
-      description
-      "Upper boundary for port.  If it
-      exists, the upper boundary must be
-      higher than the lower boundary.";
-     }
-     description
-     "Upper boundary for port.";
-    }
-     description
-     "Match on Layer 4 src port range.  When
-     only the lower-port is present, it represents
-     a single port.  When both the lower-port and
-     upper-port are specified, it implies
-     a range inclusive of both values.";
-   }
-   leaf l4-dst-port {
-    type inet:port-number;
-         must "current() < ../l4-dst-port-range/lower-port or "+
-         "current() > ../l4-dst-port-range/upper-port" {
-     description
-     "If l4-dst-port and l4-dst-port-range/lower-port
-     and upper-port are set at the same time,
-     l4-dst-port should not overlap with
-     l4-src-port-range.";
-     }
-     description
-     "Match on Layer 4 dst port.";
-   }
-   container l4-dst-port-range {
-    leaf lower-port {
-     type inet:port-number;
-     description
-     "Lower boundary for port.";
-    }
-    leaf upper-port {
-     type inet:port-number;
-     must ". >= ../lower-port" {
-     description
-     "Upper boundary must be
-     higher than lower boundary.";
-     }
-     description
-     "Upper boundary for port.  If it exists,
-     upper boundary must be higher than lower
-     boundary.";
-    }
-    description
-    "Match on Layer 4 dst port range.  When only
-    lower-port is present, it represents a single
-    port.  When both lower-port and upper-port are
-    specified, it implies a range inclusive of both
-    values.";
-   }
-   leaf protocol-field {
-    type union {
-     type uint8;
-     type identityref {
-      base protocol-type;
-     }
-    }
-    description
-    "Match on IPv4 protocol or IPv6 Next Header field.";
-   }
-   description
-   "Describes flow-matching criteria.";
-  }
-  description
-  "Flow definition based on criteria.";
- }
- grouping site-service-basic {
-  leaf svc-input-bandwidth {
-    type uint64;
-    units bps;
-    mandatory true;
-     description
-     "From the customer site's perspective, the service
-     input bandwidth of the connection or download
-     bandwidth from the SP to the site.";
-  }
-  leaf svc-output-bandwidth {
-   type uint64;
-   units bps;
-   mandatory true;
-     description
-     "From the customer site's perspective, the service
-     output bandwidth of the connection or upload
-     bandwidth from the site to the SP.";
-  }
-  leaf svc-mtu {
-   type uint16;
-   units bytes;
-   mandatory true;
-    description
-    "MTU at service level.  If the service is IP,
-    it refers to the IP MTU.  If CsC is enabled,
-    the requested 'svc-mtu' leaf will refer to the
-    MPLS MTU and not to the IP MTU.";
-  }
-  description
-  "Defines basic service parameters for a site.";
- }
- grouping site-protection {
-  container traffic-protection {
-   if-feature fast-reroute;
-   leaf enabled {
-    type boolean;
-    default false;
-     description
-     "Enables traffic protection of access link.";
-   }
-   description
-   "Fast Reroute service parameters for the site.";
-  }
-  description
-  "Defines protection service parameters for a site.";
- }
- grouping site-service-mpls {
-  container carrierscarrier {
-   if-feature carrierscarrier;
-   leaf signalling-type {
-    type enumeration {
-    enum ldp {
-     description
-     "Use LDP as the signalling protocol
-     between the PE and the CE.  In this case,
-     an IGP routing protocol must also be activated.";
-     }
-    enum bgp {
-     description
-     "Use BGP as the signalling protocol
-     between the PE and the CE.
-     In this case, BGP must also be configured as
-     the routing protocol.";
-     reference "RFC 8277: Using BGP to Bind MPLS Labels to Address Prefixes";
-     }
-    }
-    default bgp;
-    description
-    "MPLS signalling type.";
-   }
-     description
-     "This container is used when the customer provides
-     MPLS-based services.  This is only used in the case
-     of CsC (i.e., a customer builds an MPLS service using
-     an IP VPN to carry its traffic).";
-  }
-     description
-     "Defines MPLS service parameters for a site.";
- }
- grouping site-service-qos-profile {
-  container qos {
-   if-feature qos;
-   container qos-classification-policy {
-    list rule {
-     key id;
-     ordered-by user;
-     leaf id {
-      type string;
-      description
-      "A description identifying the
-       qos-classification-policy rule.";
-     }
-     choice match-type {
-      default match-flow;
-      case match-flow {
-      uses flow-definition;
-      }
-      case match-application {
-       leaf match-application {
-        type identityref {
-         base customer-application;
-        }
-         description
-         "Defines the application to match.";
-       }
-      }
-      description
-      "Choice for classification.";
-     }
-     leaf target-class-id {
-      type string;
-      description
-      "Identification of the class of service.
-      This identifier is internal to the administration.";
-     }
-     description
-     "List of marking rules.";
-    }
-    description
-    "Configuration of the traffic classification policy.";
-   }
-   container qos-profile {
-    choice qos-profile {
-     description
-     "Choice for QoS profile.
-     Can be standard profile or customized profile.";
-     case standard {
-      description
-      "Standard QoS profile.";
-      leaf profile {
-       type leafref {
-       path "/l3vpn-ntw/vpn-profiles/valid-provider-identifiers"+
-           "/qos-profile-identifier/id";
-       }
-       description
-       "QoS profile to be used.";
-      }
-      leaf direction {
-        type identityref {
-          base qos-profile-direction;}
-            default both;
-            description
-            "The direction to which the QoS profile
-            is applied.";
-      }
-     }
-     case custom {
-      description
-      "Customized QoS profile.";
-       container classes {
-        if-feature qos-custom;
-        list class {
-         key class-id;
-         leaf class-id {
-         type string;
-                  description
-                  "Identification of the class of service.
-                  This identifier is internal to the
-                  administration.";
-         }
-         leaf direction {
-                  type identityref {
-                   base qos-profile-direction;
-                   }
-                  default both;
-                   description
-                   "The direction to which the QoS profile
-                   is applied.";
-                }
-                 leaf rate-limit {
-                  type decimal64 {
-                   fraction-digits 5;
-                   range "0..100";
-          }
-                  units percent;
-                   description
-                   "To be used if the class must be rate-limited.
-                   Expressed as percentage of the service
-                   bandwidth.";
-        }
+  /* Groupings */
 
-        container latency {
-         choice flavor {
-          case lowest {
-           leaf use-lowest-latency {
-            type empty;
-             description
-             "The traffic class should use the path with the
-             lowest latency.";
-           }
-          }
-          case boundary {
-           leaf jitter-boundary {
-            type uint16;
-            units msec;
-            default 400;
-             description
-             "The traffic class should use a path with a
-             defined maximum latency.";
-           }
-          }
-          description
-          "Latency constraint on the traffic class.";
-         }
-         description
-         "Latency constraint on the traffic class.";
-        }
-        container jitter {
-         choice flavor {
-          case lowest {
-           leaf use-lowest-jitter {
-            type empty;
-             description
-             "The traffic class should use the path with the
-             lowest jitter.";
-           }
-          }
-          case boundary {
-           leaf latency-boundary {
-            type uint32;
-            units usec;
-            default 40000;
-             description
-             "The traffic class should use a path with a
-             defined maximum jitter.";
-           }
-          }
-          description
-          "Jitter constraint on the traffic class.";
-         }
-         description
-         "Jitter constraint on the traffic class.";
-        }
-        container bandwidth {
-         leaf guaranteed-bw-percent {
-          type decimal64 {
-                  fraction-digits 5;
-                  range "0..100";
-          }
-          units percent;
-          mandatory true;
-           description
-           "To be used to define the guaranteed bandwidth
-           as a percentage of the available service bandwidth.";
-         }
-         leaf end-to-end {
-          type empty;
-           description
-           "Used if the bandwidth reservation
-           must be done on the MPLS network too.";
-         }
-         description
-         "Bandwidth constraint on the traffic class.";
-        }
-        description
-        "List of classes of services.";
-       }
-       description
-       "Container for list of classes of services.";
-      }
-     }
-    }
-    description
-    "QoS profile configuration.";
-   }
-   description
-   "QoS configuration.";
-  }
-  description
-  "This grouping defines QoS parameters for a site.";
- }
- grouping site-security-authentication {
-  container authentication {
-     description
-     "Authentication parameters.";
-  }
-  description
-  "This grouping defines authentication parameters for a site.";
- }
- grouping site-security-encryption {
-  container encryption {
-    if-feature encryption;
-    leaf enabled {
-      type boolean;
-      default false;
-      description
-      "If true, traffic encryption on the connection is required.";
-    }
-     leaf layer {
-        when "../enabled = 'true'" {
-        description
-        "Require a value for layer when enabled is true.";
-       }
-      type enumeration {
-        enum layer2 {
-        description
-        "Encryption will occur at Layer 2.";
-        }
-        enum layer3 {
-        description
-        "Encryption will occur at Layer 3.
-        For example, IPsec may be used when
-        a customer requests Layer 3 encryption.";
-       }
-      }
-    description
-    "Layer on which encryption is applied.";
-    }
-    description
-    "";
-  }
-  container encryption-profile {
-    choice profile {
-      case provider-profile {
-        leaf profile-name {
-           type leafref {
-            path "/l3vpn-ntw/vpn-profiles/valid-provider-identifiers"+
-              "/encryption-profile-identifier/id";
-           }
-           description
-           "Name of the SP profile to be applied.";
-        }
-      }
-      case customer-profile {
-        leaf algorithm {
-          type string;
-          description
-          "Encryption algorithm to be used.";
-        }
-      }
-    description
-    "";
-    }
-    choice key-type {
-      default psk;
-      case psk {
-        leaf preshared-key {
-          type string;
-          description
-          "Pre-Shared Key (PSK) coming from the customer.";
-        }
-      }
-      description
-      "Choice of encryption profile.
-      The encryption profile can be the provider profile
-      or customer profile.";
-    }
-    description
-    "This grouping defines encryption parameters for a site.";
-  }
-  description
-  "";
- }
-
- grouping site-routing {
-  container routing-protocols {
-   list routing-protocol {
-    key id;
-    leaf id{
-    type string;
-    description
-    "";
-    }
-    leaf type {
-     type identityref {
-      base routing-protocol-type;
-     }
-     description
-     "Type of routing protocol.";
-    }
-
-    list routing-profiles {
-      key "id";
-
-      leaf id {
-       type leafref {
-        path "/l3vpn-ntw/vpn-profiles/valid-provider-identifiers"+
-             "/routing-profile-identifier/id";
-       }
-       description
-       "Routing profile to be used.";
-      }
-
-      leaf type {
-        type ie-type;
-        description
-        "Import, export or both.";
-      }
-
-   description
-  "Import or Export profile reference";
-    }
-
-    container ospf {
-     when "derived-from-or-self(../type, 'l3vpn-ntw:ospf')" {
-     description
-     "Only applies when protocol is OSPF.";
-     }
-     if-feature rtg-ospf;
-     leaf-list address-family {
-      type address-family;
-          min-elements "1";
-         description
-         "If OSPF is used on this site, this node
-         contains a configured value.  This node
-         contains at least one address family
-         to be activated.";
-     }
-     leaf area-address {
-      type yang:dotted-quad;
+  grouping multicast-rp-group-cfg {
+    choice group-format {
       mandatory true;
-         description
-         "Area address.";
-     }
-     leaf metric {
-      type uint16;
-      default 1;
-         description
-         "Metric of the PE-CE link.  It is used
-         in the routing state calculation and
-         path selection.";
-     }
-
-     /* Extension */
-
-
-     leaf mtu {
-         type uint16;
-         description "Maximum transmission unit for a given
-         OSPF link.";
-     }
-
-     leaf process-id {
-         type uint16;
-         description
-         "Process id of the OSPF CE-PE connection.";
-     }
-     uses security-params;
-
-     /* End of Extension */
-
-     container sham-links {
-      if-feature rtg-ospf-sham-link;
-      list sham-link {
-       key target-site;
-       leaf target-site {
-        type svc-id;
-         description
-         "Target site for the sham link connection.
-         The site is referred to by its ID.";
-       }
-       leaf metric {
-        type uint16;
-        default 1;
-         description
-         "Metric of the sham link.  It is used in
-         the routing state calculation and path
-         selection.  The default value is set
-         to 1.";
-       }
-         description
-         "Creates a sham link with another site.";
-      }
-      description
-      "List of sham links.";
-     }
-     description
-     "OSPF-specific configuration.";
-    }
-    container bgp {
-     when "derived-from-or-self(../type, 'l3vpn-ntw:bgp')" {
-      description
-      "Only applies when protocol is BGP.";
-     }
-     if-feature rtg-bgp;
-     leaf peer-autonomous-system {
-      type inet:as-number;
-      mandatory true;
-         description
-         "Customer AS number in case the customer
-         requests BGP routing.";
-     }
-    leaf local-autonomous-system {
-        type inet:as-number;
-         description
-         "Local-AS overwrite.";
-     }
-     leaf-list address-family {
-      type address-family;
-          min-elements "1";
-         description
-         "If BGP is used on this site, this node
-         contains a configured value.  This node
-         contains at least one address family
-         to be activated.";
-     }
-     /*  Extension  */
-     leaf neighbor {
-        type inet:ip-address;
-         description
-         "IP address of the BGP neighbor.";
-     }
-
-     leaf multihop {
-        type uint8;
-         description
-         "Describes the number of hops allowed between the
-         given BGP neighbor and the PE router.";
-     }
-     uses security-params;
-     uses status-params;
-
-     leaf description {
-        type string;
-         description
-         "Describes the BGP-Peer Information";
-     }
-    /* End- Extension  */
-     description
-     "BGP-specific configuration.";
-    }
-    container static {
-     when "derived-from-or-self(../type, 'l3vpn-ntw:static')" {
-       description
-       "Only applies when protocol is static.
-       BGP activation requires the SP to know
-       the address of the customer peer.  When
-       BGP is enabled, the 'static-address'
-       allocation type for the IP connection
-       MUST be used.";
-     }
-     container cascaded-lan-prefixes {
-      list ipv4-lan-prefixes {
-       if-feature ipv4;
-       key "lan next-hop";
-       leaf lan {
-        type inet:ipv4-prefix;
-        description
-        "LAN prefixes.";
-       }
-       leaf lan-tag {
-        type string;
-         description
-         "Internal tag to be used in VPN policies.";
-       }
-       leaf next-hop {
-        type inet:ipv4-address;
-         description
-         "Next-hop address to use on the customer side.";
-       }
-       description
-       "List of LAN prefixes for the site.";
-      }
-      list ipv6-lan-prefixes {
-       if-feature ipv6;
-       key "lan next-hop";
-       leaf lan {
-        type inet:ipv6-prefix;
-         description
-         "LAN prefixes.";
-       }
-       leaf lan-tag {
-        type string;
-        description
-        "Internal tag to be used in VPN policies.";
-       }
-       leaf next-hop {
-        type inet:ipv6-address;
-         description
-         "Next-hop address to use on the customer side.";
-       }
-       description
-       "List of LAN prefixes for the site.";
-      }
-      description
-      "LAN prefixes from the customer.";
-     }
-     description
-     "Configuration specific to static routing.";
-    }
-    container rip {
-     when "derived-from-or-self(../type, 'l3vpn-ntw:rip')" {
-      description
-      "Only applies when the protocol is RIP.  For IPv4,
-      the model assumes that RIP version 2 is used.";
-     }
-     if-feature rtg-rip;
-     leaf-list address-family {
-      type address-family;
-          min-elements "1";
-         description
-         "If RIP is used on this site, this node
-         contains a configured value.  This node
-         contains at least one address family
-         to be activated.";
-     }
-     description
-     "Configuration specific to RIP routing.";
-    }
-    container vrrp {
-     when "derived-from-or-self(../type, 'l3vpn-ntw:vrrp')" {
-      description
-      "Only applies when protocol is VRRP.";
-     }
-     if-feature rtg-vrrp;
-     leaf-list address-family {
-      type address-family;
-          min-elements "1";
-         description
-         "If VRRP is used on this site, this node
-         contains a configured value.  This node contains
-         at least one address family to be activated.";
-     }
-     description
-     "Configuration specific to VRRP routing.";
-    }
-    description
-    "List of routing protocols used on
-    the site.  This list can be augmented.";
-   }
-   description
-   "Defines routing protocols.";
-  }
-  description
-  "Grouping for routing protocols.";
- }
- grouping site-attachment-ip-connection {
-
-   container ip-connection {
-     container ipv4 {
-     if-feature ipv4;
-      leaf address-allocation-type {
-      type identityref {
-       base address-allocation-type;
-     }
-     must "not(derived-from-or-self(current(), 'l3vpn-ntw:slaac') or "+
-         "derived-from-or-self(current(), "+
-         "'l3vpn-ntw:provider-dhcp-slaac'))" {
-     error-message "SLAAC is only applicable to IPv6";
-     }
-     description
-     "Defines how addresses are allocated.
-     If there is no value for the address
-     allocation type, then IPv4 is not enabled.";
-    }
-   container provider-dhcp {
-     when "derived-from-or-self(../address-allocation-type, "+
-     "'l3vpn-ntw:provider-dhcp')" {
-     description
-     "Only applies when addresses are allocated by DHCP.";
-   }
-     leaf provider-address {
-      type inet:ipv4-address;
-         description
-         "Address of provider side.  If provider-address is not
-         specified, then prefix length should not be specified
-         either.  It also implies provider-dhcp allocation is
-         not enabled.  If provider-address is specified, then
-         the prefix length may or may not be specified.";
-     }
-     leaf prefix-length {
-      type uint8 {
-      range "0..32";
-      }
-         must "(../provider-address)" {
-          error-message
-          "If the prefix length is specified, provider-address
-          must also be specified.";
-             description
-             "If the prefix length is specified, provider-address
-             must also be specified.";
-        }
-     description
-     "Subnet prefix length expressed in bits.
-     If not specified, or specified as zero,
-     this means the customer leaves the actual
-     prefix length value to the provider.";
-     }
-     choice address-assign {
-      default number;
-      case number {
-       leaf number-of-dynamic-address {
-        type uint16;
-        default 1;
-         description
-         "Describes the number of IP addresses
-         the customer requires.";
-       }
-      }
-      case explicit {
-       container customer-addresses {
-        list address-group {
-         key "group-id";
-         leaf group-id {
-         type string;
-         description
-         "Group-id for the address range from
-         start-address to end-address.";
-         }
-        leaf start-address {
-         type inet:ipv4-address;
+      case singleaddress {
+        leaf group-address {
+          type inet:ip-address;
           description
-          "First address.";
-         }
-        leaf end-address {
-         type inet:ipv4-address;
-         description
-         "Last address.";
-         }
-         description
-         "Describes IP addresses allocated by DHCP.
-         When only start-address or only end-address
-         is present, it represents a single address.
-         When both start-address and end-address are
-         specified, it implies a range inclusive of both
-         addresses.  If no address is specified, it implies
-         customer addresses group is not supported.";
+            "A single multicast group address.";
         }
-         description
-         "Container for customer addresses is allocated by DHCP.";
-       }
-     }
-         description
-         "Choice for the way to assign addresses.";
-     }
-         description
-         "DHCP allocated addresses related parameters.";
-    }
- container dhcp-relay {
-   when "derived-from-or-self(../address-allocation-type, "+
-   "'l3vpn-ntw:provider-dhcp-relay')" {
-     description
-     "Only applies when provider is required to implement
-     DHCP relay function.";
-  }
- leaf provider-address {
-  type inet:ipv4-address;
-     description
-     "Address of provider side.  If provider-address is not
-     specified, then prefix length should not be specified
-     either.  It also implies provider-dhcp allocation is
-     not enabled.  If provider-address is specified, then
-     prefix length may or may not be specified.";
- }
- leaf prefix-length {
-  type uint8 {
-  range "0..32";
-  }
- must "(../provider-address)" {
-  error-message
-     "If prefix length is specified, provider-address
-      must also be specified.";
-     description
-     "If prefix length is specified, provider-address
-     must also be specified.";
-}
-     description
-     "Subnet prefix length expressed in bits.  If not
-     specified, or specified as zero, this means the
-     customer leaves the actual prefix length value
-     to the provider.";
- }
- container customer-dhcp-servers {
-  leaf-list server-ip-address {
-  type inet:ipv4-address;
-     description
-     "IP address of customer DHCP server.";
- }
- description
- "Container for list of customer DHCP servers.";
- }
- description
- "DHCP relay provided by operator.";
-}
- container static-addresses {
-   when "derived-from-or-self(../address-allocation-type, "+
-   "'l3vpn-ntw:static-address')" {
-   description
-   "Only applies when protocol allocation type is static.";
-    }
-    leaf primary-address{
-    type leafref {
-     path "/l3vpn-ntw/vpn-services/vpn-service/vpn-nodes/"+
-     "vpn-node/vpn-network-accesses/vpn-network-access/"+
-     "ip-connection/ipv4/static-addresses/address/address-id";
-    }
-    description
-    "Principal address of the connection.";
-    }
-    list address{
-    key address-id;
-     leaf address-id {
-     type string;
-     description
-     "IPv4 Address";
-     }
-     leaf provider-address {
-      type inet:ipv4-address;
-         description
-         "IPv4 Address List of the provider side.
-         When the protocol allocation type is static,
-         the provider address must be configured.";
-     }
-     leaf customer-address {
-      type inet:ipv4-address;
-         description
-         "IPv4 Address of customer side.";
-     }
-     leaf prefix-length {
-      type uint8 {
-       range "0..32";
       }
-     description
-     "Subnet prefix length expressed in bits.
-     It is applied to both provider-address
-     and customer-address.";
-     }
-     description
-     "Describes IPv4 addresses used.";
-    }
-    description
-    "Describes IPv4 addresses used.";
-    }
-    description
-    "IPv4-specific parameters.";
-   }
-   container ipv6 {
-    if-feature ipv6;
-    leaf address-allocation-type {
-     type identityref {
-      base address-allocation-type;
-     }
-     description
-     "Defines how addresses are allocated.
-     If there is no value for the address
-     allocation type, then IPv6 is
-     not enabled.";
-    }
-
-   container provider-dhcp {
-      when "derived-from-or-self(../address-allocation-type, "+
-      "'l3vpn-ntw:provider-dhcp') "+
-      "or derived-from-or-self(../address-allocation-type, "+
-      "'l3vpn-ntw:provider-dhcp-slaac')" {
+      case startend {
+        leaf group-start {
+          type inet:ip-address;
+          description
+            "The first multicast group address in
+             the multicast group address range.";
+        }
+        leaf group-end {
+          type inet:ip-address;
+          description
+            "The last multicast group address in
+             the multicast group address range.";
+        }
+      }
       description
-      "Only applies when addresses are allocated by DHCP.";
-       }
-          leaf provider-address {
-           type inet:ipv6-address;
-           description
-           "Address of the provider side.  If provider-address
-           is not specified, then prefix length should not be
-           specified either.  It also implies provider-dhcp
-           allocation is not enabled.  If provider-address is
-           specified, then prefix length may or may
-           not be specified.";
-         }
-      leaf prefix-length {
-       type uint8 {
-       range "0..128";
-       }
-           must "(../provider-address)" {
-             error-message
-             "If prefix length is specified, provider-address
-             must also be specified.";
-             description
-             "If prefix length is specified, provider-address
-             must also be specified.";
+        "Choice for multicast group format.";
+    }
+    description
+      "This grouping defines multicast group or
+       multicast groups for RP-to-group mapping.";
+  }
+
+  grouping vpn-service-multicast {
+    container multicast {
+      if-feature "l3vpn-svc:multicast";
+      leaf enabled {
+        type boolean;
+        default "false";
+        description
+          "Enables multicast.";
+      }
+      container customer-tree-flavors {
+        leaf-list tree-flavor {
+          type identityref {
+            base l3vpn-svc:multicast-tree-type;
+          }
+          description
+            "Type of tree to be used.";
+        }
+        description
+          "Type of trees used by customer.";
+      }
+      container rp {
+        container rp-group-mappings {
+          list rp-group-mapping {
+            key "id";
+            leaf id {
+              type uint16;
+              description
+                "Unique identifier for the mapping.";
             }
-       description
-       "Subnet prefix length expressed in bits.  If not
-       specified, or specified as zero, this means the
-       customer leaves the actual prefix length value
-       to the provider.";
-     }
-        choice address-assign {
-         default number;
-         case number {
-          leaf number-of-dynamic-address {
-           type uint16;
-           default 1;
-           description
-           "Describes the number of IP addresses the customer
-           requires.";
-          }
-         }
-         case explicit {
-          container customer-addresses {
-           list address-group {
-                 key "group-id";
-                 leaf group-id {
-                 type string;
-                 description
-                 "Group-id for the address range from
-                 start-address to end-address.";
-             }
-                 leaf start-address {
-                  type inet:ipv6-address;
+            container provider-managed {
+              leaf enabled {
+                type boolean;
+                default "false";
+                description
+                  "Set to true if the Rendezvous Point (RP)
+                   must be a provider-managed node.  Set to false
+                   if it is a customer-managed node.";
+              }
+              leaf rp-redundancy {
+                type boolean;
+                default "false";
+                description
+                  "If true, a redundancy mechanism for the RP
+                   is required.";
+              }
+              leaf optimal-traffic-delivery {
+                type boolean;
+                default "false";
+                description
+                  "If true, the SP must ensure that
+                   traffic uses an optimal path.  An SP may use
+                   Anycast RP or RP-tree-to-SPT switchover
+                   architectures.";
+              }
+              description
+                "Parameters for a provider-managed RP.";
+            }
+            leaf rp-address {
+              when "../provider-managed/enabled = 'false'" {
+                description
+                  "Relevant when the RP is not provider-managed.";
+              }
+              type inet:ip-address;
+              mandatory true;
+              description
+                "Defines the address of the RP.
+                 Used if the RP is customer-managed.";
+            }
+            container groups {
+              list group {
+                key "id";
+                leaf id {
+                  type uint16;
                   description
-                  "First address.";
-                  }
-                 leaf end-address {
-                  type inet:ipv6-address;
-                  description
-                  "Last address.";
-                  }
-                 description
-                 "Describes IP addresses allocated by DHCP.  When only
-                 start-address or only end-address is present, it
-                 represents a single address.  When both start-address
-                 and end-address are specified, it implies a range
-                 inclusive of both addresses.  If no address is
-                 specified, it implies customer addresses group is
-                 not supported.";
+                    "Identifier for the group.";
+                }
+                uses multicast-rp-group-cfg;
+                description
+                  "List of multicast groups.";
+              }
+              description
+                "Multicast groups associated with the RP.";
+            }
+            description
+              "List of RP-to-group mappings.";
           }
-           description
-           "Container for customer addresses allocated by DHCP.";
-         }
-        }
-         description
-         "Choice for the way to assign addresses.";
-        }
-         description
-         "DHCP allocated addresses related parameters.";
-        }
-   container dhcp-relay {
-    when "derived-from-or-self(../address-allocation-type, "+
-         "'l3vpn-ntw:provider-dhcp-relay')" {
-      description
-      "Only applies when the provider is required
-      to implement DHCP relay function.";
-      }
-        leaf provider-address {
-         type inet:ipv6-address;
           description
-          "Address of the provider side.  If provider-address is
-          not specified, then prefix length should not be
-          specified either.  It also implies provider-dhcp
-          allocation is not enabled.  If provider address
-          is specified, then prefix length may or may
-          not be specified.";
+            "RP-to-group mappings parameters.";
+        }
+        container rp-discovery {
+          leaf rp-discovery-type {
+            type identityref {
+              base l3vpn-svc:multicast-rp-discovery-type;
+            }
+            default "l3vpn-svc:static-rp";
+            description
+              "Type of RP discovery used.";
           }
-        leaf prefix-length {
-         type uint8 {
-          range "0..128";
+          container bsr-candidates {
+            when "derived-from-or-self(../rp-discovery-type, "
+               + "'l3vpn-ntw:bsr-rp')" {
+              description
+                "Only applicable if discovery type
+                 is BSR-RP.";
+            }
+            leaf-list bsr-candidate-address {
+              type inet:ip-address;
+              description
+                "Address of BSR candidate.";
+            }
+            description
+              "Container for List of Customer
+               BSR candidate's addresses.";
           }
-         must "(../provider-address)" {
-          error-message
-           "If prefix length is specified, provider-address
-           must also be specified.";
           description
-          "If prefix length is specified, provider-address
-          must also be specified.";
-           }
-         description
-         "Subnet prefix length expressed in bits.  If not
-         specified, or specified as zero, this means the
-         customer leaves the actual prefix length value
-         to the provider.";
-         }
-    container customer-dhcp-servers {
-     leaf-list server-ip-address {
-      type inet:ipv6-address;
-       description
-       "This node contains the IP address of
-       the customer DHCP server.  If the DHCP relay
-       function is implemented by the
-       provider, this node contains the
-       configured value.";
-     }
-      description
-      "Container for list of customer DHCP servers.";
-     }
-    description
-    "DHCP relay provided by operator.";
-    }
-    container static-addresses {
-      when "derived-from-or-self(../address-allocation-type, "+
-      "'l3vpn-ntw:static-address')" {
-      description
-      "Only applies when protocol allocation type is static.";
-       }
-       leaf primary-address{
-       type leafref {
-        path "/l3vpn-ntw/vpn-services/vpn-service/vpn-nodes/"+
-        "vpn-node/vpn-network-accesses/vpn-network-access/"+
-        "ip-connection/ipv6/static-addresses/address/address-id";
-       }
-       description
-       "Principal address of the connection";
-       }
-       list address{
-       key address-id;
-        leaf address-id {
-        type string;
+            "RP discovery parameters.";
+        }
         description
-        "IPv4 Address";
-        }
-    leaf provider-address {
-     type inet:ipv6-address;
+          "RP parameters.";
+      }
       description
-      "IPv6 Address of the provider side.  When the protocol
-      allocation type is static, the provider address
-      must be configured.";
-     }
-    leaf customer-address {
-     type inet:ipv6-address;
-      description
-      "The IPv6 Address of the customer side.";
-     }
-    leaf prefix-length {
-     type uint8 {
-      range "0..128";
-     }
-     description
-     "Subnet prefix length expressed in bits.
-     It is applied to both provider-address and
-     customer-address.";
+        "Multicast global parameters for the VPN service.";
     }
     description
-    "Describes IPv6 addresses used.";
-    }
-    description
-    "IPv6-specific parameters.";
-    }
-    description
-    "IPv6-specific parameters.";
-   }
-   container oam {
-    container bfd {
-     if-feature bfd;
-     leaf enabled {
+      "Grouping for multicast VPN definition.";
+  }
+
+  grouping vpn-service-mpls {
+    leaf carrierscarrier {
+      if-feature "l3vpn-svc:carrierscarrier";
       type boolean;
-      default false;
+      default "false";
       description
-      "If true, BFD activation is required.";
-     }
-     choice holdtime {
-      default fixed;
-      case fixed {
-       leaf fixed-value {
-        type uint32;
-        units msec;
-         description
-         "Expected BFD holdtime expressed in msec.  The customer
-         may impose some fixed values for the holdtime period
-         if the provider allows the customer use this function.
-         If the provider doesn't allow the customer to use this
-         function, the fixed-value will not be set.";
-       }
+        "The VPN is using CsC, and so MPLS is required.";
+    }
+    description
+      "Grouping for MPLS Carriers'Carrier definition.";
+  }
+
+  grouping operational-requirements {
+    leaf requested-site-start {
+      type yang:date-and-time;
+      description
+        "Optional leaf indicating requested date and
+         time when the service at a particular site is
+         expected to start.";
+    }
+    leaf requested-site-stop {
+      type yang:date-and-time;
+      description
+        "Optional leaf indicating requested date and
+         time when the service at a particular site is
+         expected to stop.";
+    }
+    description
+      "This grouping defines some operational
+       parameters.";
+  }
+
+  grouping operational-requirements-ops {
+    leaf actual-site-start {
+      type yang:date-and-time;
+      config false;
+      description
+        "Optional leaf indicating actual date and
+         time when the service at a particular site
+         actually started.";
+    }
+    leaf actual-site-stop {
+      type yang:date-and-time;
+      config false;
+      description
+        "Optional leaf indicating actual date and
+         time when the service at a particular site
+         actually stopped.";
+    }
+    description
+      "This grouping defines some operational
+       parameters.";
+  }
+
+  grouping site-service-basic {
+    leaf svc-input-bandwidth {
+      type uint64;
+      units "bps";
+      mandatory true;
+      description
+        "From the customer site's perspective, the service
+         input bandwidth of the connection or download
+         bandwidth from the SP to the site.";
+    }
+    leaf svc-output-bandwidth {
+      type uint64;
+      units "bps";
+      mandatory true;
+      description
+        "From the customer site's perspective, the service
+         output bandwidth of the connection or upload
+         bandwidth from the site to the SP.";
+    }
+    leaf svc-mtu {
+      type uint16;
+      units "bytes";
+      mandatory true;
+      description
+        "MTU at service level.  If the service is IP,
+         it refers to the IP MTU.  If CsC is enabled,
+         the requested 'svc-mtu' leaf will refer to the
+         MPLS MTU and not to the IP MTU.";
+    }
+    description
+      "Defines basic service parameters for a site.";
+  }
+
+  grouping site-protection {
+    container traffic-protection {
+      if-feature "l3vpn-svc:fast-reroute";
+      leaf enabled {
+        type boolean;
+        default "false";
+        description
+          "Enables traffic protection of access link.";
       }
-      case profile {
-       leaf profile-name {
-        type leafref {
-         path "/l3vpn-ntw/vpn-profiles/valid-provider-identifiers/"+
-                 "bfd-profile-identifier/id";
+      description
+        "Fast Reroute service parameters for the site.";
+    }
+    description
+      "Defines protection service parameters for a site.";
+  }
+
+  grouping site-service-mpls {
+    container carrierscarrier {
+      if-feature "l3vpn-svc:carrierscarrier";
+      leaf signalling-type {
+        type enumeration {
+          enum ldp {
+            description
+              "Use LDP as the signalling protocol
+               between the PE and the CE.  In this case,
+               an IGP routing protocol must also be activated.";
+          }
+          enum bgp {
+            description
+              "Use BGP as the signalling protocol
+               between the PE and the CE.
+               In this case, BGP must also be configured as
+               the routing protocol.";
+            reference
+              "RFC 8277: Using BGP to Bind MPLS Labels to Address Prefixes";
+          }
+        }
+        default "bgp";
+        description
+          "MPLS signalling type.";
+      }
+      description
+        "This container is used when the customer provides
+         MPLS-based services.  This is only used in the case
+         of CsC (i.e., a customer builds an MPLS service using
+         an IP VPN to carry its traffic).";
+    }
+    description
+      "Defines MPLS service parameters for a site.";
+  }
+
+  grouping site-service-qos-profile {
+    container qos {
+      if-feature "l3vpn-svc:qos";
+      container qos-classification-policy {
+        list rule {
+          key "id";
+          ordered-by user;
+          leaf id {
+            type string;
+            description
+              "A description identifying the
+               qos-classification-policy rule.";
+          }
+          choice match-type {
+            default "match-flow";
+            case match-flow {
+              uses l3vpn-svc:flow-definition;
+            }
+            case match-application {
+              leaf match-application {
+                type identityref {
+                  base l3vpn-svc:customer-application;
+                }
+                description
+                  "Defines the application to match.";
+              }
+            }
+            description
+              "Choice for classification.";
+          }
+          leaf target-class-id {
+            type string;
+            description
+              "Identification of the class of service.
+               This identifier is internal to the administration.";
+          }
+          description
+            "List of marking rules.";
         }
         description
-        "Well-known SP profile name.  The provider can propose
-        some profiles to the customer, depending on the service
-        level the customer wants to achieve.  Profile names
-        must be communicated to the customer.";
-       }
-       description
-       "Well-known SP profile.";
+          "Configuration of the traffic classification policy.";
+      }
+      container qos-profile {
+        choice qos-profile {
+          description
+            "Choice for QoS profile.
+             Can be standard profile or customized profile.";
+          case standard {
+            description
+              "Standard QoS profile.";
+            leaf profile {
+              type leafref {
+                path "/l3vpn-ntw/vpn-profiles/valid-provider-identifiers"
+                   + "/qos-profile-identifier/id";
+              }
+              description
+                "QoS profile to be used.";
+            }
+            leaf direction {
+              type identityref {
+                base l3vpn-svc:qos-profile-direction;
+              }
+              default "l3vpn-svc:both";
+              description
+                "The direction to which the QoS profile
+                 is applied.";
+            }
+          }
+          case custom {
+            description
+              "Customized QoS profile.";
+            container classes {
+              if-feature "l3vpn-svc:qos-custom";
+              list class {
+                key "class-id";
+                leaf class-id {
+                  type string;
+                  description
+                    "Identification of the class of service.
+                     This identifier is internal to the
+                     administration.";
+                }
+                leaf direction {
+                  type identityref {
+                    base l3vpn-svc:qos-profile-direction;
+                  }
+                  default "l3vpn-svc:both";
+                  description
+                    "The direction to which the QoS profile
+                     is applied.";
+                }
+                leaf rate-limit {
+                  type decimal64 {
+                    fraction-digits 5;
+                    range "0..100";
+                  }
+                  units "percent";
+                  description
+                    "To be used if the class must be rate-limited.
+                     Expressed as percentage of the service
+                     bandwidth.";
+                }
+                container latency {
+                  choice flavor {
+                    case lowest {
+                      leaf use-lowest-latency {
+                        type empty;
+                        description
+                          "The traffic class should use the path with the
+                           lowest latency.";
+                      }
+                    }
+                    case boundary {
+                      leaf jitter-boundary {
+                        type uint16;
+                        units "msec";
+                        default "400";
+                        description
+                          "The traffic class should use a path with a
+                           defined maximum latency.";
+                      }
+                    }
+                    description
+                      "Latency constraint on the traffic class.";
+                  }
+                  description
+                    "Latency constraint on the traffic class.";
+                }
+                container jitter {
+                  choice flavor {
+                    case lowest {
+                      leaf use-lowest-jitter {
+                        type empty;
+                        description
+                          "The traffic class should use the path with the
+                           lowest jitter.";
+                      }
+                    }
+                    case boundary {
+                      leaf latency-boundary {
+                        type uint32;
+                        units "usec";
+                        default "40000";
+                        description
+                          "The traffic class should use a path with a
+                           defined maximum jitter.";
+                      }
+                    }
+                    description
+                      "Jitter constraint on the traffic class.";
+                  }
+                  description
+                    "Jitter constraint on the traffic class.";
+                }
+                container bandwidth {
+                  leaf guaranteed-bw-percent {
+                    type decimal64 {
+                      fraction-digits 5;
+                      range "0..100";
+                    }
+                    units "percent";
+                    mandatory true;
+                    description
+                      "To be used to define the guaranteed bandwidth
+                       as a percentage of the available service bandwidth.";
+                  }
+                  leaf end-to-end {
+                    type empty;
+                    description
+                      "Used if the bandwidth reservation
+                       must be done on the MPLS network too.";
+                  }
+                  description
+                    "Bandwidth constraint on the traffic class.";
+                }
+                description
+                  "List of classes of services.";
+              }
+              description
+                "Container for list of classes of services.";
+            }
+          }
+        }
+        description
+          "QoS profile configuration.";
       }
       description
-      "Choice for holdtime flavor.";
-     }
-     description
-     "Container for BFD.";
+        "QoS configuration.";
     }
     description
-    "Defines the Operations, Administration, and Maintenance (OAM)
-    mechanisms used on the connection.  BFD is set as a fault
-    detection mechanism, but the 'oam' container can easily
-    be augmented by other mechanisms";
-   }
-   description
-   "Defines connection parameters.";
+      "This grouping defines QoS parameters for a site.";
   }
-  description
-  "This grouping defines IP connection parameters.";
- }
- grouping site-service-multicast {
-  container multicast {
-   if-feature multicast;
-   leaf multicast-site-type {
-    type enumeration {
-     enum receiver-only {
+
+  grouping site-security-authentication {
+    container authentication {
       description
-      "The site only has receivers.";
-     }
-     enum source-only {
-      description
-      "The site only has sources.";
-     }
-     enum source-receiver {
-      description
-      "The site has both sources and receivers.";
-     }
-    }
-    default source-receiver;
-    description
-    "Type of multicast site.";
-   }
-   container multicast-address-family {
-    leaf ipv4 {
-     if-feature ipv4;
-     type boolean;
-     default false;
-     description
-     "Enables IPv4 multicast.";
-    }
-    leaf ipv6 {
-     if-feature ipv6;
-     type boolean;
-     default false;
-     description
-     "Enables IPv6 multicast.";
+        "Authentication parameters.";
     }
     description
-    "Defines protocol to carry multicast.";
+      "This grouping defines authentication parameters for a site.";
+  }
+
+  grouping site-security-encryption {
+    container encryption {
+      if-feature "l3vpn-svc:encryption";
+      leaf enabled {
+        type boolean;
+        default "false";
+        description
+          "If true, traffic encryption on the connection is required.";
+      }
+      leaf layer {
+        when "../enabled = 'true'" {
+          description
+            "Require a value for layer when enabled is true.";
+        }
+        type enumeration {
+          enum layer2 {
+            description
+              "Encryption will occur at Layer 2.";
+          }
+          enum layer3 {
+            description
+              "Encryption will occur at Layer 3.
+               For example, IPsec may be used when
+               a customer requests Layer 3 encryption.";
+          }
+        }
+        description
+          "Layer on which encryption is applied.";
+      }
+      description
+        "";
     }
-   leaf protocol-type {
-    type enumeration {
-     enum host {
+    container encryption-profile {
+      choice profile {
+        case provider-profile {
+          leaf profile-name {
+            type leafref {
+              path "/l3vpn-ntw/vpn-profiles/valid-provider-identifiers"
+                 + "/encryption-profile-identifier/id";
+            }
+            description
+              "Name of the SP profile to be applied.";
+          }
+        }
+        case customer-profile {
+          leaf algorithm {
+            type string;
+            description
+              "Encryption algorithm to be used.";
+          }
+        }
+        description
+          "";
+      }
+      choice key-type {
+        default "psk";
+        case psk {
+          leaf preshared-key {
+            type string;
+            description
+              "Pre-Shared Key (PSK) coming from the customer.";
+          }
+        }
+        description
+          "Choice of encryption profile.
+           The encryption profile can be the provider profile
+           or customer profile.";
+      }
       description
-      "Hosts are directly connected to the provider network.
-      Host protocols such as IGMP or MLD are required.";
-     }
-     enum router {
-      description
-      "Hosts are behind a customer router.
-      PIM will be implemented.";
-     }
-     enum both {
-      description
-      "Some hosts are behind a customer router, and
-      some others are directly connected to the
-      provider network.  Both host and routing protocols
-      must be used.  Typically, IGMP and PIM will be
-      implemented.";
-     }
+        "This grouping defines encryption parameters for a site.";
     }
-    default "both";
     description
-    "Multicast protocol type to be used with the customer site.";
-   }
-   description
-   "Multicast parameters for the site.";
+      "";
   }
-  description
-  "Multicast parameters for the site.";
- }
- grouping site-maximum-routes {
-  container maximum-routes {
-   list address-family {
-    key af;
-    leaf af {
-     type address-family;
-     description
-     "Address family.";
-    }
-    leaf maximum-routes {
-     type uint32;
-     description
-     "Maximum prefixes the VRF can accept
-     for this address family.";
+
+  grouping site-routing {
+    container routing-protocols {
+      list routing-protocol {
+        key "id";
+        leaf id {
+          type string;
+          description
+            "";
+        }
+        leaf type {
+          type identityref {
+            base l3vpn-svc:routing-protocol-type;
+          }
+          description
+            "Type of routing protocol.";
+        }
+        list routing-profiles {
+          key "id";
+          leaf id {
+            type leafref {
+              path "/l3vpn-ntw/vpn-profiles/valid-provider-identifiers"
+                 + "/routing-profile-identifier/id";
+            }
+            description
+              "Routing profile to be used.";
+          }
+          leaf type {
+            type ie-type;
+            description
+              "Import, export or both.";
+          }
+          description
+            "Import or Export profile reference";
+        }
+        container ospf {
+          when "derived-from-or-self(../type, 'l3vpn-ntw:ospf')" {
+            description
+              "Only applies when protocol is OSPF.";
+          }
+          if-feature "l3vpn-svc:rtg-ospf";
+          leaf-list address-family {
+            type l3vpn-svc:address-family;
+            min-elements 1;
+            description
+              "If OSPF is used on this site, this node
+               contains a configured value.  This node
+               contains at least one address family
+               to be activated.";
+          }
+          leaf area-address {
+            type yang:dotted-quad;
+            mandatory true;
+            description
+              "Area address.";
+          }
+          leaf metric {
+            type uint16;
+            default "1";
+            description
+              "Metric of the PE-CE link.  It is used
+               in the routing state calculation and
+               path selection.";
+          }
+          /* Extension */
+          leaf mtu {
+            type uint16;
+            description
+              "Maximum transmission unit for a given
+               OSPF link.";
+          }
+          leaf process-id {
+            type uint16;
+            description
+              "Process id of the OSPF CE-PE connection.";
+          }
+          uses security-params;
+          /* End of Extension */
+          container sham-links {
+            if-feature "rtg-ospf-sham-link";
+            list sham-link {
+              key "target-site";
+              leaf target-site {
+                type l3vpn-svc:svc-id;
+                description
+                  "Target site for the sham link connection.
+                   The site is referred to by its ID.";
+              }
+              leaf metric {
+                type uint16;
+                default "1";
+                description
+                  "Metric of the sham link.  It is used in
+                   the routing state calculation and path
+                   selection.  The default value is set
+                   to 1.";
+              }
+              description
+                "Creates a sham link with another site.";
+            }
+            description
+              "List of sham links.";
+          }
+          description
+            "OSPF-specific configuration.";
+        }
+        container bgp {
+          when "derived-from-or-self(../type, 'l3vpn-ntw:bgp')" {
+            description
+              "Only applies when protocol is BGP.";
+          }
+          if-feature "l3vpn-svc:rtg-bgp";
+          leaf peer-autonomous-system {
+            type inet:as-number;
+            mandatory true;
+            description
+              "Customer AS number in case the customer
+               requests BGP routing.";
+          }
+          leaf local-autonomous-system {
+            type inet:as-number;
+            description
+              "Local-AS overwrite.";
+          }
+          leaf-list address-family {
+            type l3vpn-svc:address-family;
+            min-elements 1;
+            description
+              "If BGP is used on this site, this node
+               contains a configured value.  This node
+               contains at least one address family
+               to be activated.";
+          }
+          /*  Extension  */
+          leaf neighbor {
+            type inet:ip-address;
+            description
+              "IP address of the BGP neighbor.";
+          }
+          leaf multihop {
+            type uint8;
+            description
+              "Describes the number of hops allowed between the
+               given BGP neighbor and the PE router.";
+          }
+          uses security-params;
+          uses status-params;
+          leaf description {
+            type string;
+            description
+              "Describes the BGP-Peer Information";
+          }
+          /* End- Extension  */
+          description
+            "BGP-specific configuration.";
+        }
+        container static {
+          when "derived-from-or-self(../type, 'l3vpn-ntw:static')" {
+            description
+              "Only applies when protocol is static.
+               BGP activation requires the SP to know
+               the address of the customer peer.  When
+               BGP is enabled, the 'static-address'
+               allocation type for the IP connection
+               MUST be used.";
+          }
+          container cascaded-lan-prefixes {
+            list ipv4-lan-prefixes {
+              if-feature "l3vpn-svc:ipv4";
+              key "lan next-hop";
+              leaf lan {
+                type inet:ipv4-prefix;
+                description
+                  "LAN prefixes.";
+              }
+              leaf lan-tag {
+                type string;
+                description
+                  "Internal tag to be used in VPN policies.";
+              }
+              leaf next-hop {
+                type inet:ipv4-address;
+                description
+                  "Next-hop address to use on the customer side.";
+              }
+              description
+                "List of LAN prefixes for the site.";
+            }
+            list ipv6-lan-prefixes {
+              if-feature "l3vpn-svc:ipv6";
+              key "lan next-hop";
+              leaf lan {
+                type inet:ipv6-prefix;
+                description
+                  "LAN prefixes.";
+              }
+              leaf lan-tag {
+                type string;
+                description
+                  "Internal tag to be used in VPN policies.";
+              }
+              leaf next-hop {
+                type inet:ipv6-address;
+                description
+                  "Next-hop address to use on the customer side.";
+              }
+              description
+                "List of LAN prefixes for the site.";
+            }
+            description
+              "LAN prefixes from the customer.";
+          }
+          description
+            "Configuration specific to static routing.";
+        }
+        container rip {
+          when "derived-from-or-self(../type, 'l3vpn-ntw:rip')" {
+            description
+              "Only applies when the protocol is RIP.  For IPv4,
+               the model assumes that RIP version 2 is used.";
+          }
+          if-feature "l3vpn-svc:rtg-rip";
+          leaf-list address-family {
+            type l3vpn-svc:address-family;
+            min-elements 1;
+            description
+              "If RIP is used on this site, this node
+               contains a configured value.  This node
+               contains at least one address family
+               to be activated.";
+          }
+          description
+            "Configuration specific to RIP routing.";
+        }
+        container vrrp {
+          when "derived-from-or-self(../type, 'l3vpn-ntw:vrrp')" {
+            description
+              "Only applies when protocol is VRRP.";
+          }
+          if-feature "l3vpn-svc:rtg-vrrp";
+          leaf-list address-family {
+            type l3vpn-svc:address-family;
+            min-elements 1;
+            description
+              "If VRRP is used on this site, this node
+               contains a configured value.  This node contains
+               at least one address family to be activated.";
+          }
+          description
+            "Configuration specific to VRRP routing.";
+        }
+        description
+          "List of routing protocols used on
+           the site.  This list can be augmented.";
+      }
+      description
+        "Defines routing protocols.";
     }
     description
-    "List of address families.";
-   }
-   description
-   "Defines 'maximum-routes' for the VRF.";
+      "Grouping for routing protocols.";
   }
-  description
-  "Defines 'maximum-routes' for the site.";
- }
- grouping site-security {
-  container security {
-   uses site-security-authentication;
-   uses site-security-encryption;
-   description
-   "Site-specific security parameters.";
+
+  grouping site-attachment-ip-connection {
+    container ip-connection {
+      container ipv4 {
+        if-feature "l3vpn-svc:ipv4";
+        leaf address-allocation-type {
+          type identityref {
+            base l3vpn-svc:address-allocation-type;
+          }
+          must "not(derived-from-or-self(current(), 'l3vpn-ntw:slaac') or "
+             + "derived-from-or-self(current(), "
+             + "'l3vpn-ntw:provider-dhcp-slaac'))" {
+            error-message "SLAAC is only applicable to IPv6";
+          }
+          description
+            "Defines how addresses are allocated.
+             If there is no value for the address
+             allocation type, then IPv4 is not enabled.";
+        }
+        container provider-dhcp {
+          when "derived-from-or-self(../address-allocation-type, "
+             + "'l3vpn-ntw:provider-dhcp')" {
+            description
+              "Only applies when addresses are allocated by DHCP.";
+          }
+          leaf provider-address {
+            type inet:ipv4-address;
+            description
+              "Address of provider side.  If provider-address is not
+               specified, then prefix length should not be specified
+               either.  It also implies provider-dhcp allocation is
+               not enabled.  If provider-address is specified, then
+               the prefix length may or may not be specified.";
+          }
+          leaf prefix-length {
+            type uint8 {
+              range "0..32";
+            }
+            must '(../provider-address)' {
+              error-message
+                "If the prefix length is specified, provider-address
+                 must also be specified.";
+              description
+                "If the prefix length is specified, provider-address
+                 must also be specified.";
+            }
+            description
+              "Subnet prefix length expressed in bits.
+               If not specified, or specified as zero,
+               this means the customer leaves the actual
+               prefix length value to the provider.";
+          }
+          choice address-assign {
+            default "number";
+            case number {
+              leaf number-of-dynamic-address {
+                type uint16;
+                default "1";
+                description
+                  "Describes the number of IP addresses
+                   the customer requires.";
+              }
+            }
+            case explicit {
+              container customer-addresses {
+                list address-group {
+                  key "group-id";
+                  leaf group-id {
+                    type string;
+                    description
+                      "Group-id for the address range from
+                       start-address to end-address.";
+                  }
+                  leaf start-address {
+                    type inet:ipv4-address;
+                    description
+                      "First address.";
+                  }
+                  leaf end-address {
+                    type inet:ipv4-address;
+                    description
+                      "Last address.";
+                  }
+                  description
+                    "Describes IP addresses allocated by DHCP.
+                     When only start-address or only end-address
+                     is present, it represents a single address.
+                     When both start-address and end-address are
+                     specified, it implies a range inclusive of both
+                     addresses.  If no address is specified, it implies
+                     customer addresses group is not supported.";
+                }
+                description
+                  "Container for customer addresses is allocated by DHCP.";
+              }
+            }
+            description
+              "Choice for the way to assign addresses.";
+          }
+          description
+            "DHCP allocated addresses related parameters.";
+        }
+        container dhcp-relay {
+          when "derived-from-or-self(../address-allocation-type, "
+             + "'l3vpn-ntw:provider-dhcp-relay')" {
+            description
+              "Only applies when provider is required to implement
+               DHCP relay function.";
+          }
+          leaf provider-address {
+            type inet:ipv4-address;
+            description
+              "Address of provider side.  If provider-address is not
+               specified, then prefix length should not be specified
+               either.  It also implies provider-dhcp allocation is
+               not enabled.  If provider-address is specified, then
+               prefix length may or may not be specified.";
+          }
+          leaf prefix-length {
+            type uint8 {
+              range "0..32";
+            }
+            must '(../provider-address)' {
+              error-message
+                "If prefix length is specified, provider-address
+                 must also be specified.";
+              description
+                "If prefix length is specified, provider-address
+                 must also be specified.";
+            }
+            description
+              "Subnet prefix length expressed in bits.  If not
+               specified, or specified as zero, this means the
+               customer leaves the actual prefix length value
+               to the provider.";
+          }
+          container customer-dhcp-servers {
+            leaf-list server-ip-address {
+              type inet:ipv4-address;
+              description
+                "IP address of customer DHCP server.";
+            }
+            description
+              "Container for list of customer DHCP servers.";
+          }
+          description
+            "DHCP relay provided by operator.";
+        }
+        container static-addresses {
+          when "derived-from-or-self(../address-allocation-type, "
+             + "'l3vpn-ntw:static-address')" {
+            description
+              "Only applies when protocol allocation type is static.";
+          }
+          leaf primary-address {
+            type leafref {
+              path "/l3vpn-ntw/vpn-services/vpn-service/vpn-nodes/"
+                 + "vpn-node/vpn-network-accesses/vpn-network-access/"
+                 + "ip-connection/ipv4/static-addresses/address/address-id";
+            }
+            description
+              "Principal address of the connection.";
+          }
+          list address {
+            key "address-id";
+            leaf address-id {
+              type string;
+              description
+                "IPv4 Address";
+            }
+            leaf provider-address {
+              type inet:ipv4-address;
+              description
+                "IPv4 Address List of the provider side.
+                 When the protocol allocation type is static,
+                 the provider address must be configured.";
+            }
+            leaf customer-address {
+              type inet:ipv4-address;
+              description
+                "IPv4 Address of customer side.";
+            }
+            leaf prefix-length {
+              type uint8 {
+                range "0..32";
+              }
+              description
+                "Subnet prefix length expressed in bits.
+                 It is applied to both provider-address
+                 and customer-address.";
+            }
+            description
+              "Describes IPv4 addresses used.";
+          }
+          description
+            "Describes IPv4 addresses used.";
+        }
+        description
+          "IPv4-specific parameters.";
+      }
+      container ipv6 {
+        if-feature "l3vpn-svc:ipv6";
+        leaf address-allocation-type {
+          type identityref {
+            base l3vpn-svc:address-allocation-type;
+          }
+          description
+            "Defines how addresses are allocated.
+             If there is no value for the address
+             allocation type, then IPv6 is
+             not enabled.";
+        }
+        container provider-dhcp {
+          when "derived-from-or-self(../address-allocation-type, "
+             + "'l3vpn-ntw:provider-dhcp') "
+             + "or derived-from-or-self(../address-allocation-type, "
+             + "'l3vpn-ntw:provider-dhcp-slaac')" {
+            description
+              "Only applies when addresses are allocated by DHCP.";
+          }
+          leaf provider-address {
+            type inet:ipv6-address;
+            description
+              "Address of the provider side.  If provider-address
+               is not specified, then prefix length should not be
+               specified either.  It also implies provider-dhcp
+               allocation is not enabled.  If provider-address is
+               specified, then prefix length may or may
+               not be specified.";
+          }
+          leaf prefix-length {
+            type uint8 {
+              range "0..128";
+            }
+            must '(../provider-address)' {
+              error-message
+                "If prefix length is specified, provider-address
+                 must also be specified.";
+              description
+                "If prefix length is specified, provider-address
+                 must also be specified.";
+            }
+            description
+              "Subnet prefix length expressed in bits.  If not
+               specified, or specified as zero, this means the
+               customer leaves the actual prefix length value
+               to the provider.";
+          }
+          choice address-assign {
+            default "number";
+            case number {
+              leaf number-of-dynamic-address {
+                type uint16;
+                default "1";
+                description
+                  "Describes the number of IP addresses the customer
+                   requires.";
+              }
+            }
+            case explicit {
+              container customer-addresses {
+                list address-group {
+                  key "group-id";
+                  leaf group-id {
+                    type string;
+                    description
+                      "Group-id for the address range from
+                       start-address to end-address.";
+                  }
+                  leaf start-address {
+                    type inet:ipv6-address;
+                    description
+                      "First address.";
+                  }
+                  leaf end-address {
+                    type inet:ipv6-address;
+                    description
+                      "Last address.";
+                  }
+                  description
+                    "Describes IP addresses allocated by DHCP.  When only
+                     start-address or only end-address is present, it
+                     represents a single address.  When both start-address
+                     and end-address are specified, it implies a range
+                     inclusive of both addresses.  If no address is
+                     specified, it implies customer addresses group is
+                     not supported.";
+                }
+                description
+                  "Container for customer addresses allocated by DHCP.";
+              }
+            }
+            description
+              "Choice for the way to assign addresses.";
+          }
+          description
+            "DHCP allocated addresses related parameters.";
+        }
+        container dhcp-relay {
+          when "derived-from-or-self(../address-allocation-type, "
+             + "'l3vpn-ntw:provider-dhcp-relay')" {
+            description
+              "Only applies when the provider is required
+               to implement DHCP relay function.";
+          }
+          leaf provider-address {
+            type inet:ipv6-address;
+            description
+              "Address of the provider side.  If provider-address is
+               not specified, then prefix length should not be
+               specified either.  It also implies provider-dhcp
+               allocation is not enabled.  If provider address
+               is specified, then prefix length may or may
+               not be specified.";
+          }
+          leaf prefix-length {
+            type uint8 {
+              range "0..128";
+            }
+            must '(../provider-address)' {
+              error-message
+                "If prefix length is specified, provider-address
+                 must also be specified.";
+              description
+                "If prefix length is specified, provider-address
+                 must also be specified.";
+            }
+            description
+              "Subnet prefix length expressed in bits.  If not
+               specified, or specified as zero, this means the
+               customer leaves the actual prefix length value
+               to the provider.";
+          }
+          container customer-dhcp-servers {
+            leaf-list server-ip-address {
+              type inet:ipv6-address;
+              description
+                "This node contains the IP address of
+                 the customer DHCP server.  If the DHCP relay
+                 function is implemented by the
+                 provider, this node contains the
+                 configured value.";
+            }
+            description
+              "Container for list of customer DHCP servers.";
+          }
+          description
+            "DHCP relay provided by operator.";
+        }
+        container static-addresses {
+          when "derived-from-or-self(../address-allocation-type, "
+             + "'l3vpn-ntw:static-address')" {
+            description
+              "Only applies when protocol allocation type is static.";
+          }
+          leaf primary-address {
+            type leafref {
+              path "/l3vpn-ntw/vpn-services/vpn-service/vpn-nodes/"
+                 + "vpn-node/vpn-network-accesses/vpn-network-access/"
+                 + "ip-connection/ipv6/static-addresses/address/address-id";
+            }
+            description
+              "Principal address of the connection";
+          }
+          list address {
+            key "address-id";
+            leaf address-id {
+              type string;
+              description
+                "IPv4 Address";
+            }
+            leaf provider-address {
+              type inet:ipv6-address;
+              description
+                "IPv6 Address of the provider side.  When the protocol
+                 allocation type is static, the provider address
+                 must be configured.";
+            }
+            leaf customer-address {
+              type inet:ipv6-address;
+              description
+                "The IPv6 Address of the customer side.";
+            }
+            leaf prefix-length {
+              type uint8 {
+                range "0..128";
+              }
+              description
+                "Subnet prefix length expressed in bits.
+                 It is applied to both provider-address and
+                 customer-address.";
+            }
+            description
+              "Describes IPv6 addresses used.";
+          }
+          description
+            "IPv6-specific parameters.";
+        }
+        description
+          "IPv6-specific parameters.";
+      }
+      container oam {
+        container bfd {
+          if-feature "l3vpn-svc:bfd";
+          leaf enabled {
+            type boolean;
+            default "false";
+            description
+              "If true, BFD activation is required.";
+          }
+          choice holdtime {
+            default "fixed";
+            case fixed {
+              leaf fixed-value {
+                type uint32;
+                units "msec";
+                description
+                  "Expected BFD holdtime expressed in msec.  The customer
+                   may impose some fixed values for the holdtime period
+                   if the provider allows the customer use this function.
+                   If the provider doesn't allow the customer to use this
+                   function, the fixed-value will not be set.";
+              }
+            }
+            case profile {
+              leaf profile-name {
+                type leafref {
+                  path "/l3vpn-ntw/vpn-profiles/valid-provider-identifiers/"
+                     + "bfd-profile-identifier/id";
+                }
+                description
+                  "Well-known SP profile name.  The provider can propose
+                   some profiles to the customer, depending on the service
+                   level the customer wants to achieve.  Profile names
+                   must be communicated to the customer.";
+              }
+              description
+                "Well-known SP profile.";
+            }
+            description
+              "Choice for holdtime flavor.";
+          }
+          description
+            "Container for BFD.";
+        }
+        description
+          "Defines the Operations, Administration, and Maintenance (OAM)
+           mechanisms used on the connection.  BFD is set as a fault
+           detection mechanism, but the 'oam' container can easily
+           be augmented by other mechanisms";
+      }
+      description
+        "Defines connection parameters.";
+    }
+    description
+      "This grouping defines IP connection parameters.";
   }
-  description
-  "Grouping for security parameters.";
- }
- grouping network-access-service {
-  container service {
-   uses site-service-basic;
-   /* Extension */
-   /* uses svc-bandwidth-params; */
-   /* EoExt */
-   uses site-service-qos-profile;
-   uses site-service-mpls;
-   uses site-service-multicast;
-   description
-   "Service parameters on the attachment.";
+
+  grouping site-service-multicast {
+    container multicast {
+      if-feature "l3vpn-svc:multicast";
+      leaf multicast-site-type {
+        type enumeration {
+          enum receiver-only {
+            description
+              "The site only has receivers.";
+          }
+          enum source-only {
+            description
+              "The site only has sources.";
+          }
+          enum source-receiver {
+            description
+              "The site has both sources and receivers.";
+          }
+        }
+        default "source-receiver";
+        description
+          "Type of multicast site.";
+      }
+      container multicast-address-family {
+        leaf ipv4 {
+          if-feature "l3vpn-svc:ipv4";
+          type boolean;
+          default "false";
+          description
+            "Enables IPv4 multicast.";
+        }
+        leaf ipv6 {
+          if-feature "l3vpn-svc:ipv6";
+          type boolean;
+          default "false";
+          description
+            "Enables IPv6 multicast.";
+        }
+        description
+          "Defines protocol to carry multicast.";
+      }
+      leaf protocol-type {
+        type enumeration {
+          enum host {
+            description
+              "Hosts are directly connected to the provider network.
+               Host protocols such as IGMP or MLD are required.";
+          }
+          enum router {
+            description
+              "Hosts are behind a customer router.
+               PIM will be implemented.";
+          }
+          enum both {
+            description
+              "Some hosts are behind a customer router, and
+               some others are directly connected to the
+               provider network.  Both host and routing protocols
+               must be used.  Typically, IGMP and PIM will be
+               implemented.";
+          }
+        }
+        default "both";
+        description
+          "Multicast protocol type to be used with the customer site.";
+      }
+      description
+        "Multicast parameters for the site.";
+    }
+    description
+      "Multicast parameters for the site.";
   }
-  description
-  "Grouping for service parameters.";
- }
- grouping vpn-extranet {
-  container extranet-vpns {
-   if-feature extranet-vpn;
-   list extranet-vpn {
-    key vpn-id;
+
+  grouping site-maximum-routes {
+    container maximum-routes {
+      list address-family {
+        key "af";
+        leaf af {
+          type l3vpn-svc:address-family;
+          description
+            "Address family.";
+        }
+        leaf maximum-routes {
+          type uint32;
+          description
+            "Maximum prefixes the VRF can accept
+             for this address family.";
+        }
+        description
+          "List of address families.";
+      }
+      description
+        "Defines 'maximum-routes' for the VRF.";
+    }
+    description
+      "Defines 'maximum-routes' for the site.";
+  }
+
+  grouping site-security {
+    container security {
+      uses site-security-authentication;
+      uses site-security-encryption;
+      description
+        "Site-specific security parameters.";
+    }
+    description
+      "Grouping for security parameters.";
+  }
+
+  grouping network-access-service {
+    container service {
+      uses site-service-basic;
+      /* Extension */
+      /* uses svc-bandwidth-params; */
+      /* EoExt */
+      uses site-service-qos-profile;
+      uses site-service-mpls;
+      uses site-service-multicast;
+      description
+        "Service parameters on the attachment.";
+    }
+    description
+      "Grouping for service parameters.";
+  }
+
+  grouping vpn-extranet {
+    container extranet-vpns {
+      if-feature "l3vpn-svc:extranet-vpn";
+      list extranet-vpn {
+        key "vpn-id";
+        leaf vpn-id {
+          type l3vpn-svc:svc-id;
+          description
+            "Identifies the target VPN the local VPN want to access.";
+        }
+        leaf local-sites-role {
+          type identityref {
+            base l3vpn-svc:site-role;
+          }
+          default "l3vpn-svc:any-to-any-role";
+          description
+            "This describes the role of the
+             local sites in the target VPN topology.  In the any-to-any VPN
+             service topology, the local sites must have the same role, which
+             will be 'any-to-any-role'.  In the Hub-and-Spoke VPN service
+             topology or the Hub-and-Spoke disjoint VPN service topology,
+             the local sites must have a Hub role or a Spoke role.";
+        }
+        description
+          "List of extranet VPNs or target VPNs the local VPN is
+           attached to.";
+      }
+      description
+        "Container for extranet VPN configuration.";
+    }
+    description
+      "Grouping for extranet VPN configuration.
+       This provides an easy way to interconnect
+       all sites from two VPNs.";
+  }
+
+  grouping vpn-profile-cfg {
+    container valid-provider-identifiers {
+      list cloud-identifier {
+        if-feature "l3vpn-svc:cloud-access";
+        key "id";
+        leaf id {
+          type string;
+          description
+            "Identification of cloud service.
+             Local administration meaning.";
+        }
+        description
+          "List for Cloud Identifiers.";
+      }
+      list encryption-profile-identifier {
+        key "id";
+        leaf id {
+          type string;
+          description
+            "Identification of the SP encryption profile
+             to be used.  Local administration meaning.";
+        }
+        description
+          "List for encryption profile identifiers.";
+      }
+      list qos-profile-identifier {
+        key "id";
+        leaf id {
+          type string;
+          description
+            "Identification of the QoS Profile to be used.
+             Local administration meaning.";
+        }
+        description
+          "List for QoS Profile Identifiers.";
+      }
+      list bfd-profile-identifier {
+        key "id";
+        leaf id {
+          type string;
+          description
+            "Identification of the SP BFD Profile to be used.
+             Local administration meaning.";
+        }
+        description
+          "List for BFD Profile identifiers.";
+      }
+      list routing-profile-identifier {
+        key "id";
+        leaf id {
+          type string;
+          description
+            "Identification of the routing Profile to be used
+             by the routing-protocols within sites and vpn-
+             network-accesses. Local administration meaning.";
+        }
+        description
+          "List for Routing Profile Identifiers.";
+      }
+      nacm:default-deny-write;
+      description
+        "Container for Valid Provider Identifies.";
+    }
+    description
+      "Grouping for VPN Profile configuration.";
+  }
+
+  grouping vpn-svc-cfg {
     leaf vpn-id {
-     type svc-id;
-     description
-     "Identifies the target VPN the local VPN want to access.";
+      type l3vpn-svc:svc-id;
+      description
+        "VPN identifier.  Local administration meaning.";
     }
-    leaf local-sites-role {
-     type identityref {
-      base site-role;
-     }
-     default any-to-any-role;
-     description
-     "This describes the role of the
-     local sites in the target VPN topology.  In the any-to-any VPN
-     service topology, the local sites must have the same role, which
-     will be 'any-to-any-role'.  In the Hub-and-Spoke VPN service
-     topology or the Hub-and-Spoke disjoint VPN service topology,
-     the local sites must have a Hub role or a Spoke role.";
+    leaf customer-name {
+      type string;
+      description
+        "Name of the customer that actually uses the VPN service.
+         In the case that any intermediary (e.g., Tier-2 provider
+         or partner) sells the VPN service to their end user
+         on behalf of the original service provider (e.g., Tier-1
+         provider), the original service provider may require the
+         customer name to provide smooth activation/commissioning
+         and operation for the service.";
     }
+    leaf vpn-service-topology {
+      type identityref {
+        base l3vpn-svc:vpn-topology;
+      }
+      default "l3vpn-svc:any-to-any";
+      description
+        "VPN service topology.";
+    }
+    leaf description {
+      type string;
+      description
+        "Textual description of a VPN service.";
+    }
+    uses ie-profiles-params;
+    uses vpn-nodes-params;
+    uses vpn-service-multicast;
+    /* uses vpn-service-mpls; */
+    /* uses vpn-extranet;*/
     description
-    "List of extranet VPNs or target VPNs the local VPN is
-    attached to.";
-   }
-   description
-   "Container for extranet VPN configuration.";
-  }
-  description
-  "Grouping for extranet VPN configuration.
-  This provides an easy way to interconnect
-  all sites from two VPNs.";
- }
- grouping vpn-profile-cfg {
-  container valid-provider-identifiers {
-   list cloud-identifier {
-    if-feature cloud-access;
-    key id;
-    leaf id {
-     type string;
-     description
-     "Identification of cloud service.
-     Local administration meaning.";
-    }
-    description
-    "List for Cloud Identifiers.";
-   }
-   list encryption-profile-identifier {
-    key id;
-    leaf id {
-     type string;
-     description
-     "Identification of the SP encryption profile
-     to be used.  Local administration meaning.";
-    }
-    description
-    "List for encryption profile identifiers.";
-   }
-   list qos-profile-identifier {
-    key id;
-    leaf id {
-     type string;
-     description
-     "Identification of the QoS Profile to be used.
-     Local administration meaning.";
-    }
-    description
-    "List for QoS Profile Identifiers.";
-   }
-   list bfd-profile-identifier {
-    key id;
-    leaf id {
-     type string;
-     description
-     "Identification of the SP BFD Profile to be used.
-     Local administration meaning.";
-    }
-    description
-    "List for BFD Profile identifiers.";
-   }
-
-   list routing-profile-identifier {
-    key id;
-    leaf id {
-     type string;
-     description
-     "Identification of the routing Profile to be used
-     by the routing-protocols within sites and vpn-
-     network-accesses. Local administration meaning.";
-    }
-    description
-    "List for Routing Profile Identifiers.";
-   }
-
-     nacm:default-deny-write;
-     description
-     "Container for Valid Provider Identifies.";
+      "Grouping for VPN service configuration.";
   }
 
-   description
-   "Grouping for VPN Profile configuration.";
- }
- grouping vpn-svc-cfg {
-  leaf vpn-id {
-   type svc-id;
-   description
-   "VPN identifier.  Local administration meaning.";
-  }
-  leaf customer-name {
-   type string;
-   description
-   "Name of the customer that actually uses the VPN service.
-   In the case that any intermediary (e.g., Tier-2 provider
-   or partner) sells the VPN service to their end user
-   on behalf of the original service provider (e.g., Tier-1
-   provider), the original service provider may require the
-   customer name to provide smooth activation/commissioning
-   and operation for the service.";
-  }
-  leaf vpn-service-topology {
-   type identityref {
-    base vpn-topology;
-   }
-   default any-to-any;
-   description
-   "VPN service topology.";
-  }
-
-  leaf description {
-    type string;
+  grouping site-network-access-top-level-cfg {
+    uses status-params;
+    leaf vpn-network-access-type {
+      type identityref {
+        base l3vpn-svc:site-network-access-type;
+      }
+      default "l3vpn-svc:point-to-point";
+      description
+        "Describes the type of connection, e.g.,
+         point-to-point or multipoint.";
+    }
+    uses ethernet-params;
+    uses site-attachment-ip-connection;
+    uses site-security;
+    uses site-routing;
+    uses network-access-service;
     description
-      "Textual description of a VPN service.";
+      "Grouping for site network access top-level configuration.";
   }
-
-  uses ie-profiles-params;
-  uses vpn-nodes-params;
-  uses vpn-service-multicast;
-  /* uses vpn-service-mpls; */
-  /* uses vpn-extranet;*/
-  description
-  "Grouping for VPN service configuration.";
- }
- grouping site-network-access-top-level-cfg {
-  uses status-params;
-  leaf vpn-network-access-type {
-   type identityref {
-    base site-network-access-type;
-   }
-   default point-to-point;
-   description
-   "Describes the type of connection, e.g.,
-   point-to-point or multipoint.";
-  }
-  uses ethernet-params;
-  uses site-attachment-ip-connection;
-  uses site-security;
-  uses site-routing;
-  uses network-access-service;
-  description
-  "Grouping for site network access top-level configuration.";
- }
 
   /* Bearers in a site */
-   grouping site-bearer-params {
+
+  grouping site-bearer-params {
     container site-bearers {
       list bearer {
         key "bearer-id";
         leaf bearer-id {
           type string;
-          description "";
+          description
+            "";
         }
         leaf BearerType {
-        type identityref {
-          base bearer-inf-type;
+          type identityref {
+            base bearer-inf-type;
+          }
+          description
+            "Request for an Bearer access type.
+             Choose between port or lag connection type.";
         }
-        description
-          "Request for an Bearer access type.
-          Choose between port or lag connection type.";
-        }
-
         leaf ne-id {
           type string;
-        description
-          "NE-id reference.";
+          description
+            "NE-id reference.";
         }
-
         leaf port-id {
           type string;
           description
-          "Port-id in format slot/ card /port.";
+            "Port-id in format slot/ card /port.";
         }
         leaf lag-id {
           type string;
           description
-          "lag-id in format id.";
-        }
-     description
-    "Parameters used to identify each bearer";
-      }
-    description
-    "Grouping to reuse the site bearer assigment";
-    }
-    description
-    "Grouping to reuse the site bearer assigment";
-   }
-
-   /* UNUSED */
-   grouping svc-bandwidth-params {
-     container svc-bandwidth {
-        if-feature "input-bw";
-        list bandwidth {
-          key "direction type";
-          leaf direction {
-            type identityref {
-              base bw-direction;
-            }
-            description
-              "Indicates the bandwidth direction.  It can be
-               the bandwidth download direction from the SP to
-               the site or the bandwidth upload direction from
-               the site to the SP.";
-          }
-          leaf type {
-            type identityref {
-              base bw-type;
-            }
-            description
-              "Bandwidth type.  By default, the bandwidth type
-               is set to 'bw-per-cos'.";
-          }
-          leaf cos-id {
-            when "derived-from-or-self(../type, "
-               + "'l3vpn-ntw:bw-per-cos')" {
-              description
-                "Relevant when the bandwidth type is set to
-                 'bw-per-cos'.";
-            }
-            type uint8;
-            description
-              "Identifier of the CoS, indicated by DSCP or a
-               CE-VLAN CoS (802.1p) value in the service frame.
-               If the bandwidth type is set to 'bw-per-cos',
-               the CoS ID MUST also be specified.";
-          }
-          leaf vpn-id {
-            when "derived-from-or-self(../type, "
-               + "'l3vpn-ntw:bw-per-svc')" {
-              description
-                "Relevant when the bandwidth type is
-                 set as bandwidth per VPN service.";
-            }
-            type svc-id;
-            description
-              "Identifies the target VPN.  If the bandwidth
-               type is set as bandwidth per VPN service, the
-               vpn-id MUST be specified.";
-          }
-          leaf cir {
-            type uint64;
-            units "bps";
-            mandatory true;
-            description
-              "Committed Information Rate.  The maximum number
-               of bits that a port can receive or send over
-               an interface in one second.";
-          }
-          leaf cbs {
-            type uint64;
-            units "bps";
-            mandatory true;
-            description
-              "Committed Burst Size (CBS).  Controls the bursty
-               nature of the traffic.  Traffic that does not
-               use the configured Committed Information Rate
-               (CIR) accumulates credits until the credits
-               reach the configured CBS.";
-          }
-          leaf eir {
-            type uint64;
-            units "bps";
-            description
-              "Excess Information Rate (EIR), i.e., excess frame
-               delivery allowed that is not subject to an SLA.
-               The traffic rate can be limited by the EIR.";
-          }
-          leaf ebs {
-            type uint64;
-            units "bps";
-            description
-              "Excess Burst Size (EBS).  The bandwidth available
-               for burst traffic from the EBS is subject to the
-               amount of bandwidth that is accumulated during
-               periods when traffic allocated by the EIR
-               policy is not used.";
-          }
-          leaf pir {
-            type uint64;
-            units "bps";
-            description
-              "Peak Information Rate, i.e., maximum frame
-               delivery allowed.  It is equal to or less
-               than the sum of the CIR and the EIR.";
-          }
-          leaf pbs {
-            type uint64;
-            units "bps";
-            description
-              "Peak Burst Size.  It is measured in bytes per
-               second.";
-          }
-          description
-            "List of bandwidth values (e.g., per CoS,
-             per vpn-id).";
+            "lag-id in format id.";
         }
         description
-          "From the customer site's perspective, the service
-           input/output bandwidth of the connection or
-           download/upload bandwidth from the SP/site
-           to the site/SP.";
-     }
-         description
-          " ";
-   }
+          "Parameters used to identify each bearer";
+      }
+      description
+        "Grouping to reuse the site bearer assigment";
+    }
+    description
+      "Grouping to reuse the site bearer assigment";
+  }
 
+  /* UNUSED */
+
+  grouping svc-bandwidth-params {
+    container svc-bandwidth {
+      if-feature "input-bw";
+      list bandwidth {
+        key "direction type";
+        leaf direction {
+          type identityref {
+            base bw-direction;
+          }
+          description
+            "Indicates the bandwidth direction.  It can be
+             the bandwidth download direction from the SP to
+             the site or the bandwidth upload direction from
+             the site to the SP.";
+        }
+        leaf type {
+          type identityref {
+            base bw-type;
+          }
+          description
+            "Bandwidth type.  By default, the bandwidth type
+             is set to 'bw-per-cos'.";
+        }
+        leaf cos-id {
+          when "derived-from-or-self(../type, "
+             + "'l3vpn-ntw:bw-per-cos')" {
+            description
+              "Relevant when the bandwidth type is set to
+               'bw-per-cos'.";
+          }
+          type uint8;
+          description
+            "Identifier of the CoS, indicated by DSCP or a
+             CE-VLAN CoS (802.1p) value in the service frame.
+             If the bandwidth type is set to 'bw-per-cos',
+             the CoS ID MUST also be specified.";
+        }
+        leaf vpn-id {
+          when "derived-from-or-self(../type, "
+             + "'l3vpn-ntw:bw-per-svc')" {
+            description
+              "Relevant when the bandwidth type is
+               set as bandwidth per VPN service.";
+          }
+          type l3vpn-svc:svc-id;
+          description
+            "Identifies the target VPN.  If the bandwidth
+             type is set as bandwidth per VPN service, the
+             vpn-id MUST be specified.";
+        }
+        leaf cir {
+          type uint64;
+          units "bps";
+          mandatory true;
+          description
+            "Committed Information Rate.  The maximum number
+             of bits that a port can receive or send over
+             an interface in one second.";
+        }
+        leaf cbs {
+          type uint64;
+          units "bps";
+          mandatory true;
+          description
+            "Committed Burst Size (CBS).  Controls the bursty
+             nature of the traffic.  Traffic that does not
+             use the configured Committed Information Rate
+             (CIR) accumulates credits until the credits
+             reach the configured CBS.";
+        }
+        leaf eir {
+          type uint64;
+          units "bps";
+          description
+            "Excess Information Rate (EIR), i.e., excess frame
+             delivery allowed that is not subject to an SLA.
+             The traffic rate can be limited by the EIR.";
+        }
+        leaf ebs {
+          type uint64;
+          units "bps";
+          description
+            "Excess Burst Size (EBS).  The bandwidth available
+             for burst traffic from the EBS is subject to the
+             amount of bandwidth that is accumulated during
+             periods when traffic allocated by the EIR
+             policy is not used.";
+        }
+        leaf pir {
+          type uint64;
+          units "bps";
+          description
+            "Peak Information Rate, i.e., maximum frame
+             delivery allowed.  It is equal to or less
+             than the sum of the CIR and the EIR.";
+        }
+        leaf pbs {
+          type uint64;
+          units "bps";
+          description
+            "Peak Burst Size.  It is measured in bytes per
+             second.";
+        }
+        description
+          "List of bandwidth values (e.g., per CoS,
+           per vpn-id).";
+      }
+      description
+        "From the customer site's perspective, the service
+         input/output bandwidth of the connection or
+         download/upload bandwidth from the SP/site
+         to the site/SP.";
+    }
+    description
+      " ";
+  }
 
   grouping status-params {
     container status {
       leaf admin-enabled {
         type boolean;
         description
-        "Administrative Status UP/DOWN";
+          "Administrative Status UP/DOWN";
       }
       leaf oper-status {
         type operational-type;
         config false;
         description
-        "Operations status";
+          "Operations status";
       }
-      description "";
+      description
+        "";
     }
     description
-    "Grouping used to join operational and administrative status
-    is re used in the Site Network Acess and in the VPN-Node";
+      "Grouping used to join operational and administrative status
+       is re used in the Site Network Acess and in the VPN-Node";
   }
 
-
   /* Parameters related to vpn-nodes (VRF config.) */
-   grouping vpn-nodes-params {
-    container vpn-nodes {
-      description "";
 
+  grouping vpn-nodes-params {
+    container vpn-nodes {
+      description
+        "";
       list vpn-node {
         key "vpn-node-id ne-id";
-
         leaf vpn-node-id {
           type string;
-          description "";
+          description
+            "";
         }
-
         leaf autonomous-system {
-         type inet:as-number;
-            description
+          type inet:as-number;
+          description
             "Provider AS number in case the customer
-            requests BGP routing.";
+             requests BGP routing.";
         }
-
         leaf description {
           type string;
           description
@@ -2686,67 +2144,67 @@ identity site-to-wan {
         }
         leaf ne-id {
           type string;
-          description "";
+          description
+            "";
         }
-
         leaf router-id {
           type inet:ip-address;
           description
-          "router-id information can be ipv4/6 addresses";
+            "router-id information can be ipv4/6 addresses";
         }
-
         leaf address-family {
-         type address-family;
-         description
-         "Address family used for router-id information.";
+          type l3vpn-svc:address-family;
+          description
+            "Address family used for router-id information.";
         }
-
         leaf node-role {
           type identityref {
-            base site-role;
+            base l3vpn-svc:site-role;
           }
-          default any-to-any-role;
+          default "l3vpn-svc:any-to-any-role";
           description
-          "Role of the vpn-node in the IP VPN.";
+            "Role of the vpn-node in the IP VPN.";
         }
         uses rt-rd;
         uses status-params;
         uses net-acc;
-
         uses site-maximum-routes;
-
         leaf node-ie-profile {
           type leafref {
-            path "/l3vpn-ntw/vpn-services/"+
-                 "vpn-service/ie-profiles/ie-profile/ie-profile-id";
+            path "/l3vpn-ntw/vpn-services/"
+               + "vpn-service/ie-profiles/ie-profile/ie-profile-id";
           }
-          description "";
+          description
+            "";
         }
-      description "";
+        description
+          "";
       }
     }
-    description "Grouping to define VRF-specific configuration.";
-   }
+    description
+      "Grouping to define VRF-specific configuration.";
+  }
 
   /* Parameters related to import and export profiles (RTs RDs.) */
-   grouping ie-profiles-params {
+
+  grouping ie-profiles-params {
     container ie-profiles {
       list ie-profile {
         key "ie-profile-id";
         leaf ie-profile-id {
           type string;
-        description
-           "";
+          description
+            "";
         }
         uses rt-rd;
-    description
-    "";
+        description
+          "";
       }
-    description
-    "";
+      description
+        "";
     }
     description
-    "Grouping to specify rules for route import and export";
+      "Grouping to specify rules for route import and export";
   }
 
   grouping pseudowire-params {
@@ -2758,19 +2216,19 @@ identity site-to-wan {
       leaf vcid {
         type uint32;
         description
-        "PW or VC identifier.";
+          "PW or VC identifier.";
       }
       leaf far-end {
         type union {
           type uint32;
-          type inet:ipv4-address;}
+          type inet:ipv4-address;
+        }
         description
-        "SDP/Far End/LDP Neighbour reference.";
+          "SDP/Far End/LDP Neighbour reference.";
       }
-    description
-    "Pseudowire termination parameters";
+      description
+        "Pseudowire termination parameters";
     }
-
     container vpls {
       leaf vcid {
         type union {
@@ -2778,270 +2236,266 @@ identity site-to-wan {
           type string;
         }
         description
-        "VCID identifier,IRB/RVPPLs interface
-        supported using string
-        format.";
+          "VCID identifier,IRB/RVPPLs interface
+           supported using string
+           format.";
       }
       leaf far-end {
         type union {
           type uint32;
-          type inet:ipv4-address;}
+          type inet:ipv4-address;
+        }
         description
-        "SDP/Far End/LDP Neighbour reference.";
+          "SDP/Far End/LDP Neighbour reference.";
       }
-    description
-    "Pseudowire termination parameters";
+      description
+        "Pseudowire termination parameters";
     }
-
-
-     description
-    "Grouping pseudowire termination parameters";
+    description
+      "Grouping pseudowire termination parameters";
   }
 
   grouping security-params {
     container security {
-    leaf auth-key {
+      leaf auth-key {
         type string;
         description
           "MD5 authentication password for the connection towards the
-          customer edge.";
+           customer edge.";
       }
-    description
+      description
         "Container for aggregating any security parameter for routing
-        sessions between a PE and a CE.";
+         sessions between a PE and a CE.";
     }
     description
-    "Grouping to define security parameters";
+      "Grouping to define security parameters";
   }
 
-grouping ethernet-params {
-  container connection {
-    leaf encapsulation-type {
-      type identityref {
-        base encapsulation-type;
-      }
-      default "untagged-int";
-      description
-        "Encapsulation type.  By default, the
-         encapsulation type is set to 'untagged'.";
-    }
-    container tagged-interface {
-      leaf type {
+  grouping ethernet-params {
+    container connection {
+      leaf encapsulation-type {
         type identityref {
-          base tagged-inf-type;
+          base encapsulation-type;
         }
-        default "priority-tagged";
+        default "untagged-int";
         description
-          "Tagged interface type.  By default,
-           the type of the tagged interface is
-           'priority-tagged'.";
+          "Encapsulation type.  By default, the
+           encapsulation type is set to 'untagged'.";
       }
-      container dot1q-vlan-tagged {
-        when "derived-from-or-self(../type, "
-           + "'l3vpn-ntw:dot1q')" {
-          description
-            "Only applies when the type of the tagged
-             interface is 'dot1q'.";
-        }
-        if-feature "dot1q";
-        leaf tag-type {
+      container tagged-interface {
+        leaf type {
           type identityref {
-            base tag-type;
+            base tagged-inf-type;
           }
-          default "c-vlan";
+          default "priority-tagged";
           description
-            "Tag type.  By default, the tag type is
-             'c-vlan'.";
-          }
-        leaf cvlan-id {
-          type uint16;
-          description
-            "VLAN identifier.";
-          }
-        description
-          "Tagged interface.";
-      }
-      container priority-tagged {
-        when "derived-from-or-self(../type, "
-           + "'l3vpn-ntw:priority-tagged')" {
-          description
-            "Only applies when the type of the tagged
-             interface is 'priority-tagged'.";
+            "Tagged interface type.  By default,
+             the type of the tagged interface is
+             'priority-tagged'.";
         }
-        leaf tag-type {
-          type identityref {
-            base tag-type;
-          }
-          default "c-vlan";
-          description
-            "Tag type.  By default, the tag type is
-             'c-vlan'.";
-        }
-        description
-          "Priority tagged.";
-      }
-      container qinq {
-        when "derived-from-or-self(../type, "
-           + "'l3vpn-ntw:qinq')" {
-          description
-            "Only applies when the type of the tagged
-             interface is 'qinq'.";
-        }
-        if-feature "qinq";
-        leaf tag-type {
-          type identityref {
-            base tag-type;
-          }
-          default "c-s-vlan";
-          description
-            "Tag type.  By default, the tag type is
-             'c-s-vlan'.";
-        }
-        leaf svlan-id {
-          type uint16;
-          mandatory true;
-          description
-            "SVLAN identifier.";
-        }
-        leaf cvlan-id {
-          type uint16;
-          mandatory true;
-          description
-            "CVLAN identifier.";
-        }
-        description
-          "QinQ.";
-      }
-      container qinany {
-        when "derived-from-or-self(../type, "
-           + "'l3vpn-ntw:qinany')" {
-          description
-            "Only applies when the type of the tagged
-             interface is 'qinany'.";
-        }
-        if-feature "qinany";
-        leaf tag-type {
-          type identityref {
-            base tag-type;
-          }
-          default "s-vlan";
-          description
-            "Tag type.  By default, the tag type is
-             's-vlan'.";
-        }
-        leaf svlan-id {
-          type uint16;
-          mandatory true;
-          description
-            "Service VLAN ID.";
-        }
-        description
-          "Container for QinAny.";
-      }
-      container vxlan {
-        when "derived-from-or-self(../type, "
-           + "'l3vpn-ntw:vxlan')" {
-          description
-            "Only applies when the type of the tagged
-             interface is 'vxlan'.";
-        }
-        if-feature "vxlan";
-        leaf vni-id {
-          type uint32;
-          mandatory true;
-          description
-            "VXLAN Network Identifier (VNI).";
-        }
-        leaf peer-mode {
-          type identityref {
-            base vxlan-peer-mode;
-          }
-          default "static-mode";
-          description
-            "Specifies the VXLAN access mode.  By default,
-             the peer mode is set to 'static-mode'.";
-        }
-        list peer-list {
-          key "peer-ip";
-          leaf peer-ip {
-            type inet:ip-address;
+        container dot1q-vlan-tagged {
+          when "derived-from-or-self(../type, "
+             + "'l3vpn-ntw:dot1q')" {
             description
-              "Peer IP.";
+              "Only applies when the type of the tagged
+               interface is 'dot1q'.";
+          }
+          if-feature "dot1q";
+          leaf tag-type {
+            type identityref {
+              base tag-type;
+            }
+            default "c-vlan";
+            description
+              "Tag type.  By default, the tag type is
+               'c-vlan'.";
+          }
+          leaf cvlan-id {
+            type uint16;
+            description
+              "VLAN identifier.";
           }
           description
-            "List of peer IP addresses.";
+            "Tagged interface.";
+        }
+        container priority-tagged {
+          when "derived-from-or-self(../type, "
+             + "'l3vpn-ntw:priority-tagged')" {
+            description
+              "Only applies when the type of the tagged
+               interface is 'priority-tagged'.";
+          }
+          leaf tag-type {
+            type identityref {
+              base tag-type;
+            }
+            default "c-vlan";
+            description
+              "Tag type.  By default, the tag type is
+               'c-vlan'.";
+          }
+          description
+            "Priority tagged.";
+        }
+        container qinq {
+          when "derived-from-or-self(../type, "
+             + "'l3vpn-ntw:qinq')" {
+            description
+              "Only applies when the type of the tagged
+               interface is 'qinq'.";
+          }
+          if-feature "qinq";
+          leaf tag-type {
+            type identityref {
+              base tag-type;
+            }
+            default "c-s-vlan";
+            description
+              "Tag type.  By default, the tag type is
+               'c-s-vlan'.";
+          }
+          leaf svlan-id {
+            type uint16;
+            mandatory true;
+            description
+              "SVLAN identifier.";
+          }
+          leaf cvlan-id {
+            type uint16;
+            mandatory true;
+            description
+              "CVLAN identifier.";
+          }
+          description
+            "QinQ.";
+        }
+        container qinany {
+          when "derived-from-or-self(../type, "
+             + "'l3vpn-ntw:qinany')" {
+            description
+              "Only applies when the type of the tagged
+               interface is 'qinany'.";
+          }
+          if-feature "qinany";
+          leaf tag-type {
+            type identityref {
+              base tag-type;
+            }
+            default "s-vlan";
+            description
+              "Tag type.  By default, the tag type is
+               's-vlan'.";
+          }
+          leaf svlan-id {
+            type uint16;
+            mandatory true;
+            description
+              "Service VLAN ID.";
+          }
+          description
+            "Container for QinAny.";
+        }
+        container vxlan {
+          when "derived-from-or-self(../type, "
+             + "'l3vpn-ntw:vxlan')" {
+            description
+              "Only applies when the type of the tagged
+               interface is 'vxlan'.";
+          }
+          if-feature "vxlan";
+          leaf vni-id {
+            type uint32;
+            mandatory true;
+            description
+              "VXLAN Network Identifier (VNI).";
+          }
+          leaf peer-mode {
+            type identityref {
+              base vxlan-peer-mode;
+            }
+            default "static-mode";
+            description
+              "Specifies the VXLAN access mode.  By default,
+               the peer mode is set to 'static-mode'.";
+          }
+          list peer-list {
+            key "peer-ip";
+            leaf peer-ip {
+              type inet:ip-address;
+              description
+                "Peer IP.";
+            }
+            description
+              "List of peer IP addresses.";
+          }
+          description
+            "QinQ.";
         }
         description
-          "QinQ.";
+          "Container for tagged interfaces.";
+      }
+      container bearer {
+        leaf bearer-reference {
+          if-feature "l3vpn-svc:bearer-reference";
+          type string;
+          description
+            "This is an internal reference for the SP.";
+        }
+        uses pseudowire-params {
+          when "/l3vpn-ntw/vpn-services/vpn-service/vpn-nodes/"
+             + "vpn-node/vpn-network-accesses/vpn-network-access/"
+             + "vpn-network-access-type ='pseudowire'" {
+            description
+              "pseudowire specific parameters";
+          }
+        }
+        description
+          "Defines physical properties of a site attachment.";
       }
       description
-        "Container for tagged interfaces.";
-    }
-    container bearer {
-     leaf bearer-reference {
-      if-feature bearer-reference;
-      type string;
-       description
-       "This is an internal reference for the SP.";
-     }
-       uses pseudowire-params {
-          when "/l3vpn-ntw/vpn-services/vpn-service/vpn-nodes/"+
-          "vpn-node/vpn-network-accesses/vpn-network-access/"+
-          "vpn-network-access-type ='pseudowire'"
-        {
-          description "pseudowire specific parameters";
-          }
-       }
-    description
-    "Defines physical properties of a site attachment.";
+        "Encapsulation types";
     }
     description
-    "Encapsulation types";
+      "Grouping to define encapsulation types";
   }
-    description
-    "Grouping to define encapsulation types";
-}
 
-grouping rt-rd {
-  leaf rd {
-    type rt-types:route-distinguisher;
-    description
-    "";
+  grouping rt-rd {
+    leaf rd {
+      type rt-types:route-distinguisher;
+      description
+        "";
     }
     container vpn-targets {
+      description
+        "Set of route-targets to match for import and export routes
+         to/from VRF";
+      //uses rt-types:vpn-route-targets;
+      uses vpn-route-targets;
+    }
     description
-    "Set of route-targets to match for import and export routes
-     to/from VRF";
-     uses vpn-route-targets;
-     }
-  description
-  "";
-}
+      "";
+  }
 
   grouping vpn-route-targets {
     description
       "A grouping that specifies Route Target import-export rules
-       used in the BGP enabled Virtual Private Networks (VPNs).";
-    reference
-      "RFC4364: BGP/MPLS IP Virtual Private Networks (VPNs).
-       RFC4664: Framework for Layer 2 Virtual Private Networks
-       (L2VPNs)";
+       used in a BGP-enabled VPN.";
     list vpn-target {
-      key id;
+      key "id";
       leaf id {
         type int8;
         description
-        "Identifies each VPN Target";
+          "Identifies each VPN Target";
       }
-       list route-targets{ 
-       key route-target;
+      list route-targets {
+        key "route-target";
         leaf route-target {
           type rt-types:route-target;
           description
             "Route Target value";
         }
-      description
-        "List of Route Targets.";
+        description
+          "List of Route Targets.";
       }
       leaf route-target-type {
         type rt-types:route-target-type;
@@ -3050,57 +2504,61 @@ grouping rt-rd {
           "Import/export type of the Route Target.";
       }
     }
+    reference
+      "RFC4364: BGP/MPLS IP Virtual Private Networks (VPNs)
+       RFC4664: Framework for Layer 2 Virtual Private Networks
+       (L2VPNs)";
   }
 
-grouping net-acc{
-container vpn-network-accesses {
-     list vpn-network-access {
-      key vpn-network-access-id;
-      leaf vpn-network-access-id {
-       type svc-id;
-       description
-       "Identifier for the access.";
-      }
-      leaf port-id {
-       type svc-id;
-       description
-       "Identifier for the network access.";
-      }
-      leaf description {
-        type string;
+  grouping net-acc {
+    container vpn-network-accesses {
+      list vpn-network-access {
+        key "vpn-network-access-id";
+        leaf vpn-network-access-id {
+          type l3vpn-svc:svc-id;
+          description
+            "Identifier for the access.";
+        }
+        leaf port-id {
+          type l3vpn-svc:svc-id;
+          description
+            "Identifier for the network access.";
+        }
+        leaf description {
+          type string;
+          description
+            "Textual description of a VPN service.";
+        }
+        uses site-network-access-top-level-cfg;
         description
-          "Textual description of a VPN service.";
+          "List of accesses for a site.";
       }
-      uses site-network-access-top-level-cfg;
       description
-      "List of accesses for a site.";
-     }
-     description
-     "List of accesses for a site.";
-     }
-     description
-     "Main block of the Network Access.";
-}
-
-
- /* Main blocks */
- container l3vpn-ntw {
-  container vpn-profiles {
-   uses vpn-profile-cfg;
+        "List of accesses for a site.";
+    }
     description
-    "Container for VPN Profiles.";
+      "Main block of the Network Access.";
   }
-  container vpn-services {
-   list vpn-service {
-    key vpn-id;
-    uses vpn-svc-cfg;
+
+  /* Main Blocks */
+
+  container l3vpn-ntw {
+    container vpn-profiles {
+      uses vpn-profile-cfg;
+      description
+        "Container for VPN Profiles.";
+    }
+    container vpn-services {
+      list vpn-service {
+        key "vpn-id";
+        uses vpn-svc-cfg;
+        description
+          "List of VPN services.";
+      }
+      description
+        "Top-level container for the VPN services.";
+    }
     description
-    "List of VPN services.";
-   }
-   description
-   "Top-level container for the VPN services.";
+      "Main container for L3VPN service configuration.";
   }
-  description
-  "Main container for L3VPN service configuration.";
- }
 }


### PR DESCRIPTION
- reuse identities, typedefs, and feature from L3SM. Focus only on specific ones
- no need to redefine flow definition: We can reuse existing ones.
If more match attributes are needed, we may consider reusing RFC8519.
- run "pyang -f yang --keep-comments"

Replaces PR#64ab947 