### PR TITLE
Pointer to the L3SM service

### DIFF
--- a/yang/IETF-02/ietf-l3vpn-ntw.yang
+++ b/yang/IETF-02/ietf-l3vpn-ntw.yang
@@ -2018,6 +2018,11 @@ module ietf-l3vpn-ntw {
       description
         "VPN identifier.  Local administration meaning.";
     }
+    leaf l3sm-vpn-id {
+      type l3vpn-svc:svc-id;
+      description
+        "Pointer to the L3SM service.";
+    }
     leaf customer-name {
       type string;
       description


### PR DESCRIPTION
Allows a controller to expose the service (L3SM) to which L3NM vpn service is bound.