### PR TITLE
MSDP - changed tree location

### DIFF
--- a/yang/IETF-02/ietf-l3vpn-ntw.yang
+++ b/yang/IETF-02/ietf-l3vpn-ntw.yang
@@ -499,22 +499,6 @@ module ietf-l3vpn-ntw {
                   description
                   "Address other RP routers that share the same RP IP address.";
                 }
-                container msdp {
-                  if-feature msdp;
-                  leaf enabled {
-                    type boolean;
-                    default false;
-                    description
-                    "If true, Multicast Source Discovery Protocol (MSDP) protocol is activated.";
-                  }
-                  leaf peer {
-                    type inet:ip-address;
-                    description
-                    "IP address of the MSDP peer.";
-                  }
-                  description 
-                  "MSDP parameters.";
-                }
                 description 
                 "PIM Anycast-RP parameters.";
               }  
@@ -577,6 +561,27 @@ module ietf-l3vpn-ntw {
             description
               "Container for List of Customer
                BSR candidate's addresses.";
+            }   
+          container msdp {
+            if-feature msdp;
+            leaf enabled {
+              type boolean;
+              default false;
+              description
+              "If true, Multicast Source Discovery Protocol (MSDP) protocol is activated.";
+            }
+            leaf peer {
+              type inet:ip-address;
+              description
+              "IP address of the MSDP peer.";
+            }
+            leaf local-address{
+              type inet:ip-address;
+              description
+              "IP address of the local end. This local address must be configured on the node.";
+            }
+            description 
+            "MSDP parameters.";
           }
           description
             "RP discovery parameters.";


### PR DESCRIPTION
#45 Since MSDP protocol is independent from PIM-anycast, it is better to update the location under rp-discovery container. Also for MSDP to work properly, it needs to have at least one peer. When configuring a peer, local-address must be declared at local end.