### PR TITLE
Remove RFC4076 as it is weird to be cited in the draft

### DIFF
--- a/I-D-L3NM/draft-ietf-opsawg-l3sm-l3nm-01.xml
+++ b/I-D-L3NM/draft-ietf-opsawg-l3sm-l3nm-01.xml
@@ -8,7 +8,6 @@
 <!ENTITY RFC2119 SYSTEM "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.2119.xml">
 <!ENTITY RFC3688 SYSTEM "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.3688.xml">
 <!ENTITY RFC4026 SYSTEM "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.4026.xml">
-<!ENTITY RFC4076 SYSTEM "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.4076.xml">
 <!ENTITY RFC4176 SYSTEM "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.4176.xml">
 <!ENTITY RFC6020 SYSTEM "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.6020.xml">
 <!ENTITY RFC6241 SYSTEM "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.6241.xml">
@@ -274,7 +273,7 @@
 
         <t>The document is aimed at modeling BGP PE-based VPNs in a Service
         Provider Network, so the terms defined in <xref target="RFC4026"/> and
-        <xref target="RFC4076"/> are used.</t>
+        <xref target="RFC4176"/> are used.</t>
 
         <t>This document makes use of the following terms:</t>
 
@@ -4509,8 +4508,6 @@ container vpn-network-accesses {
 
     <references title="Informative References">
       &RFC4026;
-
-      &RFC4076;
 
       &RFC8299;
 


### PR DESCRIPTION
The document does not cover renumbering matter or DHCPv6.