### PR TITLE
Multicast group prefix instead of address

### DIFF
--- a/yang/IETF-02/ietf-l3vpn-ntw.yang
+++ b/yang/IETF-02/ietf-l3vpn-ntw.yang
@@ -434,11 +434,11 @@ module ietf-l3vpn-ntw {
   grouping multicast-rp-group-cfg {
     choice group-format {
       mandatory true;
-      case singleaddress {
+      case group-prefix {
         leaf group-address {
-          type inet:ip-address;
+          type inet:ip-prefix;
           description
-            "A single multicast group address.";
+            "A single multicast group prefix.";
         }
       }
       case startend {


### PR DESCRIPTION
Issue #83 RP-group address  value should have a ip-prefix format.