### PR TITLE
Update transport-encapsulation grouping

### DIFF
--- a/yang/IETF-02/ietf-l3vpn-ntw.yang
+++ b/yang/IETF-02/ietf-l3vpn-ntw.yang
@@ -469,8 +469,8 @@ module ietf-l3vpn-ntw {
   /* Groupings */
 
   grouping svc-transport-encapsulation {
-    container transport-encapsulation {
-      leaf protocol {
+    container underlay-transport {
+      leaf type {
         type protocols-type;
         description
           "Protocols used to support transport";
@@ -2135,6 +2135,7 @@ module ietf-l3vpn-ntw {
         "Textual description of a VPN service.";
     }
     uses ie-profiles-params;
+    uses svc-transport-encapsulation;
     uses vpn-nodes-params;
     /* uses vpn-service-multicast; */
     /* uses vpn-service-mpls; */
@@ -2399,7 +2400,6 @@ module ietf-l3vpn-ntw {
         uses net-acc;
         uses site-maximum-routes;
         uses vpn-service-multicast;
-        uses svc-transport-encapsulation;
         leaf node-ie-profile {
           type leafref {
             path "/l3vpn-ntw/vpn-services/"


### PR DESCRIPTION
Issue #66. Container "transport-encapsulation" has now the name "underlay-transport" for improving its suitability meaning. The same reason applys to the leaf "protocol", that has been updated to "type", since not all the enum items are protocols but technologies.

Also, it applies to vpn-service level, not vpn-node level.